### PR TITLE
small assortment of bug fixes and doc enhancements

### DIFF
--- a/scripts/run-js-tests.sh
+++ b/scripts/run-js-tests.sh
@@ -7,7 +7,8 @@ RUN_LOG="$RESULT_DIR"/coverage_short.log
 
 shopt -s globstar nullglob
 
-RUN_MODE="FULL_REPORTS"
+RUN_MODE="FULL"
+RUN_TYPE="WITH_REPORTS"
 
 TESTS=()
 while [ "$#" -gt 0 ]; do
@@ -22,7 +23,7 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
       '--config-only') RUN_MODE="no-test" ;;
       '--skip-config') RUN_MODE="no-config" ;;
-      '--with-reports') RUN_MODE="FULL_REPORTS" ;;
+      '--with-reports') RUN_TYPE="WITH_REPORTS" ;;
       '--run-name') RUN_NAME="$2"; shift ;;
       # assume $1 to be a globbing pattern and try to treat it as such
       *) IFS= TESTS+=($1) ;; 
@@ -69,7 +70,7 @@ else
   export TEST_TIMINGS=hotspots
 fi
 
-if isRelease || [[ "$RUN_MODE" =~ .+_REPORTS$ ]]; then
+if isRelease || [[ "$RUN_TYPE" =~ .+_REPORTS$ ]]; then
   echo "Release build (or used '--with-reports'): Also generate LCOV report"
   TEST_REPORTERS+=("--test-reporter=lcov" "--test-reporter-destination=$RESULT_DIR/js.coverage.info")
 fi

--- a/sources/fs-root/opt/emulatorlauncher/lib/.controls.lib
+++ b/sources/fs-root/opt/emulatorlauncher/lib/.controls.lib
@@ -179,7 +179,7 @@ function _controls:amx-configure {
 controller_profile=${controller_profile:-none}
 if [ "$controller_profile" != "none" ]; then
   _logAndOut "Controller profile configured - disable/block controller inputs from game"
-  _launchPrefix+=("firejail --noprofile --noinput")
+  _launchPrefix+=(firejail --noprofile --noinput)
   
   _controls:amx-configure \
     || _interface:errorAbort "Failed to configure profile for [controller_profile=$controller_profile]"

--- a/sources/fs-root/opt/emulatorlauncher/lib/.operations.lib
+++ b/sources/fs-root/opt/emulatorlauncher/lib/.operations.lib
@@ -81,6 +81,24 @@ function effectiveProperties {
   return $?
 }
 
+# @description
+# This function prints properties coming from btc-config in a bash-sourceable way.
+# There are 2 use cases for this:
+# 1. During debugging. However, there is also the function `launchConfiguration` which also contains more than just the properties
+# 2. When writing custom launcher shell scripts, which will be started from a system/emulator adapter file.  
+#  
+# This function is especially useful for case 2:  
+# Adapter files are sourced, but the launchCommand they provide is not because it can be any executable. 
+# Thus, any further subshell started from emulatorlauncher will normally NOT see all those all rom properties, 
+# if they are not exported or passed via config file.    
+# This function can be used as a convenient tool to write the variables to such a configuration file.
+# @internal
+function declaredVars {
+  for v in "${_declaredVars[@]}"; do
+    declare -p "$v"
+  done
+}
+
 function launchConfiguration {
   # shellcheck disable=SC2145
   echo launchCommand=\("${launchCommand[@]}"\)
@@ -88,9 +106,7 @@ function launchConfiguration {
   for c in "${configFiles[@]}"; do
     echo "configFiles+=('$c')"
   done
-  for v in "${_declaredVars[@]}"; do
-    declare -p "$v"
-  done
+  declaredVars
 }
 
 # @description By default, all additional operations to **not** prevent launch of the game.  
@@ -114,7 +130,9 @@ function notifyListener {
   done
 }
 
-# internal usage - print full configuration when launch command fails
+# @description
+# print full configuration when launch command fails
+# @internal
 function debugOutputOnError {
   [ "$launchResult" = "0" ] && return
   _logAndOut "Failed to launch [$rom] with configuration:"

--- a/sources/fs-root/opt/emulatorlauncher/windows_installers_any_any.sh
+++ b/sources/fs-root/opt/emulatorlauncher/windows_installers_any_any.sh
@@ -1,4 +1,4 @@
-launchCommand=("$FS_ROOT"/usr/bin/emulationstation-wine install "'$rom'" -cfg "$CONFIG_FILE_PATH")
+launchCommand=("$FS_ROOT"/usr/bin/emulationstation-wine install "$absRomPath" -cfg "$CONFIG_FILE_PATH")
 cat << EOF > "$CONFIG_FILE_PATH" 
 export INSTALL_DATE="$(date)"
 EOF

--- a/sources/fs-root/opt/emulatorlauncher/wine_any.sh
+++ b/sources/fs-root/opt/emulatorlauncher/wine_any.sh
@@ -1,4 +1,4 @@
-launchCommand=("$FS_ROOT"/usr/bin/emulationstation-wine run "'$rom'" -cfg "$CONFIG_FILE_PATH")
+launchCommand=("$FS_ROOT"/usr/bin/emulationstation-wine run "$absRomPath" -cfg "$CONFIG_FILE_PATH")
 
 if [ "$core" = "dxvk" ]; then
   dxvk="${dxvk:-1}"
@@ -6,7 +6,9 @@ else
   dxvk="0"
 fi
 
-cat << EOF > "$CONFIG_FILE_PATH" 
+cat << EOF > "$CONFIG_FILE_PATH"
+$(declaredVars)
+ 
 export DXVK="${dxvk:-0}"
 export DXVK_HUD="${dxvk_hud:-0}"
 export DXVK_ENABLE_NVAPI="${dxvk_enable_nvapi:-0}"

--- a/sources/fs-root/usr/bin/emulationstation-wine
+++ b/sources/fs-root/usr/bin/emulationstation-wine
@@ -199,7 +199,7 @@ function _generateDxvkLayer {
 # 3. `userPrefix`: These are based on library prefixes, but use fuse and overlay mounts to create user-specific directory structures when starting a game. 
 #
 # While the game runs, all of its writes go into the overlay. This overlay will be decoupled when it stops.
-# With that, it becomes possible to update/modify the library prefix with invalidating user saves in the overlay.
+# With that, it becomes possible to update/modify the library prefix without invalidating user saves in the overlay.
 # 
 # This approach has its limits and can fail when a file exists in both the library and the save and is modified differently in both.
 

--- a/sources/fs-root/usr/bin/emulatorlauncher
+++ b/sources/fs-root/usr/bin/emulatorlauncher
@@ -6,7 +6,7 @@
 #
 # These steps are:
 # 1. Parse command line
-# 2. Determine effective properties for the game
+# 2. Determine and load effective properties for the game.
 # 3. Configure [controls](../../dev/files/opt/emulatorlauncher/lib/.controls.lib.md)
 # 4. Configure system/emulator
 # 4. Execute additional [pre-game operations](emulatorlauncher-operations.md)

--- a/test/shell/opt/emulatorlauncher/lib/controls.lib.test.js
+++ b/test/shell/opt/emulatorlauncher/lib/controls.lib.test.js
@@ -56,7 +56,7 @@ class ControlsLibTest extends ShellTestRunner {
       if (profileValue == "none") {
         this.verifyVariable('_launchPrefix', ['']);
       } else {
-        this.verifyVariable('_launchPrefix', [`firejail --noprofile --noinput`]);
+        this.verifyVariable('_launchPrefix', ['firejail', '--noprofile', '--noinput']);
       }
       if (profileValue.startsWith('u-')) {
         this.environment({


### PR DESCRIPTION
- running tests on github doesn't try to generate config 2 times any longer
- windows_installer/wine adapter now correctly use 'absRomPath'
- some small rewording in docs
- wine adapter properly passes on effectiveProperties to emulationstation-wine
- AMX handling: firejail arguments must not be quoted, or bash will consider the blanks to be part of the command itself, which fails