### PR TITLE
New generic writer option: keyPrefix

### DIFF
--- a/sources/fs-root/opt/batocera-emulationstation/btc-config
+++ b/sources/fs-root/opt/batocera-emulationstation/btc-config
@@ -96,13 +96,12 @@ API.configureRomPaths = api.action(
     }
   });
 
-// FIXME: make more usable
 API.convert = api.action(
   () => {
     let parsers = require('io/parsers');
     let writers = require('io/writers');
 
-    let propertyMatch = /(\w+)=([\w\s]+)/;
+    let propertyMatch = /(\w+)=(.*)/;
     testfn = (input) => propertyMatch.test(input);
     return {
       '*1': 1, '--as': parsers.FORMATS, '*--to': writers.FORMATS.REGULAR,

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/cmdline/help.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/cmdline/help.js
@@ -69,6 +69,21 @@ The labels will be placed on a templated XBOX controller, at the positions where
 At the moment, it does not detect if buttons are swapped by using a different SDL configuration/button mapping.`
   },
 
+  'convert': {
+    brief: 'Convert a property file from one format to another. Output to stdout.',
+    fullSpec: 
+      `Can read any of the supported property file formats. By default, parser type is determined by file ending,
+but it can also be enforced manually.
+The output of some formats is configurable by using '--options'. The options to use are the internal names used in property writers:
+ - verbose                  (all)
+ - createRootKeysDictFile   (all)
+ - keyPrefix                (all)
+ - printSource              (conf, sh)
+ - comment                  (conf, xml)
+ - stripPrefix              (sh)
+ - declareCommand           (sh)`
+  },
+
   effectiveGlobals: {
     brief: `get or set os-wide (=global) property. 'get' prints on stdout.`,
     fullSpec:

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/writers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/writers.js
@@ -8,7 +8,7 @@
  * all of the writers.
  * 
  * **Currently supported:**
- * - yaml
+ * - yaml (basic subset)
  * - json
  * - xml
  * - conf (batocera-specific format)
@@ -16,6 +16,7 @@
  * - features (es_features.cfg)
  * - systems (es_systems.cfg)
  * - settings (es_settings.cfg)
+ * - plain (just stringifies whatever value or value[] is passed in)
  *  
  * To use a writer, use `requiredModule[formatName].write(dictionary, fileOrStream, options)`. 
  * 
@@ -73,12 +74,12 @@ function xmlEncode(data = null, visited = []) {
 
 /**
  * Assign given default to property with the given name if it is not defined.
- * Includes special treatment for PropValue instances
+ * Includes special treatment for PropValue instances.
  */
 function setDefault(object, prop, defaultValue) {
   if (object[prop] instanceof PropValue && isEmpty(object[prop].value)) {
     object[prop].value = defaultValue;
-  } else if (typeof object[prop] == "undefined") {
+  } else if (isEmpty(object[prop])) {
     object[prop] = defaultValue;
   }
 }
@@ -120,10 +121,11 @@ class Writer {
    * **About `options`**
    * `options` are a way to control the behaviour of writers. It is a simple dictionary.  
    * Most options are writer-specific. The generic entry method supports 2 options at the moment:
-   * 1. `options.verbose=boolean`: Add a log statement when the actual writing using `writeDict` begins.
-   * 2. `options.createRootKeysDictFile=/path/to/file`:
+   * 1. `verbose=boolean`: Add a log statement when the actual writing using `writeDict` begins.
+   * 2. `createRootKeysDictFile=/path/to/file`:
    *     This generates a 'summary' file at the specified location which contains only the root keys of `dict`.  
    *     This option is mostly used for logic simplification during config import and for detection of supported systems.
+   * 3.  `keyPrefix=string`: Prepends the given value to all root keys.
    *   
    * Some options are supported by multiple writers:
    * - `options.printSource=boolean`: 
@@ -136,6 +138,14 @@ class Writer {
     log.debug(`Using [${actualWriter.constructor.name}] for file [${actualWriter.filename}] with options:`, options);
     try {
       if (options.verbose) { log.userOnly(`Writing ${targetFile}`) }
+      if (typeof options.keyPrefix == "string") {
+        let prefix = options.keyPrefix;
+        let remapped = Object.create(Object.getPrototypeOf(dict));
+        for (let k in dict) {
+          remapped[prefix + k] = dict[k];
+        }
+        dict = remapped;
+      }
       actualWriter.writeDict(dict, options);
       //optionally create a generated summary cache file of the root keys
       //useful as a filter for merges etc
@@ -179,7 +189,7 @@ class Writer {
  * aside from those handled by the generic {Writer}. But these do not make much sense to use here.
  */
 class PlainWriter extends Writer {
-  writeDict(dict) { this.write(String(dict)) }
+  writeDict(dict) { this.write(asString(dict)) }
 }
 
 /**
@@ -189,8 +199,8 @@ class PlainWriter extends Writer {
  * 3. Nested `dict` structures will be flattened first
  *   
  * **Supported options:**
- * - `options.comment=string`: no comment when not given
- * - `options.printSource=boolean`: default false
+ * - `comment=string`: no comment when not given
+ * - `printSource=boolean`: default false
  */
 class ConfWriter extends Writer {
   writeDict(dict, options) {
@@ -242,7 +252,7 @@ class YamlWriter extends Writer {
  * serving different purposes. There exist dedicated writes for most of them because they are so different.  
  * 
  * **Supported options:**
- * - `options.comment=string`: no comment when not given
+ * - `comment=string`: no comment when not given
  */
 class XmlWriter extends Writer {
   writeDict(dict, options = {}) {
@@ -285,6 +295,17 @@ class XmlWriter extends Writer {
   }
 }
 
+/**
+ * Write object graphs as sourceable shell code.  
+ *   
+ * **Supported options:**
+ * - `declareCommand=string`: shell command used to declare variables.  
+ *   Can be any visible/exported function from the calling context.
+ * - `printSource=boolean`: default false
+ * - `stripPrefix=int`: default 0. Remove (up to) n levels of HierarchicKey segments from each property path.  
+ *   Applies a bit of logic to ensure the resulting top-level could would not be an integer, but an actual word.  
+ *   Example: stripPrefix=2, `a.b.c=5 => c=5`, `a.b[3]=true => b[3]="true"` (both have 3 segments).
+ */
 class ShellWriter extends Writer {
   writeDict(dict, options) {
     let resultKeyLevelStart = options.stripPrefix || 0;
@@ -292,6 +313,7 @@ class ShellWriter extends Writer {
     let reorganized = {};
     let declaredProps = {};
 
+    let toplevelPrefix = typeof options.keyPrefix == "string" ? options.keyPrefix : "";
     for (let k of keys) {
       let adjustedKey = [0];
       let reducedStart = Math.min(resultKeyLevelStart, k.length);
@@ -307,6 +329,9 @@ class ShellWriter extends Writer {
       if (typeof declaredProps[adjustedKey] != "undefined") {
         log.warn('Property name collision on sublevel after prefix ()%s stripping (overriding previous):\n\t%s\n\t%s',
           resultKeyLevelStart, declaredProps[adjustedKey], k);
+      }
+      if (!String(adjustedKey).startsWith(toplevelPrefix)) {
+        adjustedKey[0] = toplevelPrefix + adjustedKey[0];
       }
       declaredProps[adjustedKey] = k;
       adjustedKey.set(reorganized, k.get(dict));
@@ -336,10 +361,9 @@ class ShellWriter extends Writer {
 /**
  * This writer implementation is meant to specifically generate the file `es_settings.cfg`.  
  * `EmulationStation` uses several `*.cfg` files, but they don't share a common structure in terms of properties.
- * The only th
  */
 class EsSettingsWriter extends XmlWriter {
-  static GAME_SPECIFIC = /^[\-\w]+\.game\[/
+  static GAME_SPECIFIC = /^[\-\w]+\.game\[/;
   writeDict(dict, options) {
     let imploded = deepImplode(dict);
     let docRoot = { config: {} }
@@ -406,6 +430,9 @@ class EsSystemsWriter extends Writer {
     if (!options.attributes.includes('key')) options.attributes.unshift('key');
     options.filter ||= () => true;
 
+    //make a working copy because we are going to change it during parsing
+    // note: this will delete the `source` info of PropValue 
+    dict = JSON.parse(JSON.stringify(dict));
     // recursively go through all value strings and encode them to be compatible to XML
     dict = xmlEncode(dict);
 
@@ -458,6 +485,7 @@ class EsFeaturesWriter extends Writer {
     options.filter ||= () => true;
 
     //make a working copy because we are going to change it during parsing
+    // note: this will delete the `source` info of PropValue
     dict = JSON.parse(JSON.stringify(dict));
     // recursively go through all value strings and encode them to be compatible to XML
     dict = xmlEncode(dict);


### PR DESCRIPTION
This PR adds a new capability to the generic writer API: `option.keyPrefix=string`.

Any top-level key in the root object will just be prefixed blindly with the given string value. This is mostly useful when parsing and converting property files on the command line with `btc-config convert`.

Also added tests and docs.

While this will theoretically work with ALL writers, it is fundamentally incompatible to the `systems` and `features` writers, because those do not write arbitrary **properties**, but require a fixed structure.