### PR TITLE
Several bugfixes related to shell handling

### DIFF
--- a/sources/fs-root/opt/batocera-emulationstation/lib/generic-utils.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/generic-utils.lib
@@ -82,6 +82,16 @@ function _containsKey {
 }
 export -f _containsKey
 
+# @description Checks that given variable names exist and contain a value. Exit if otherwise.
+function _requireVars {
+  while [ -n "$1" ]; do
+    declare -n required="$1"
+    required="${required?$1}"
+    shift
+  done
+}
+export -f _requireVars
+
 _hasFunc _checkOutdated || \
 # @internal
 # @description

--- a/sources/fs-root/opt/batocera-emulationstation/lib/interaction_helpers.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/interaction_helpers.lib
@@ -157,7 +157,9 @@ function _interface:errorAbort {
     _logOnly "ERROR: $@"
     _interface:baseDialog --error "--text=$(printf '%s ' "$@")"
   else
-    _logAndOut "ERROR: $@"
+    # reset current status to prevent undesired executions of -e/-E through status propagation of log functions
+    # not an issue because this is a controlled shutdown using regular `exit 1`
+    true && _logAndOut "ERROR: $@"
   fi
   exit 1
 }

--- a/sources/fs-root/opt/batocera-emulationstation/lib/launcher-base.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/launcher-base.lib
@@ -189,20 +189,28 @@ source "$SH_LIB_DIR"/interaction_helpers.lib
 # Commands can be anything understood by bash (which is also visible to the current process).  
 # Every entry in the exit hook array will be eval'd, so use with utmost care!
 
-EXIT_HOOKS=('[ "$?" == 0 ] || _logAndOut "Failed at [${BASH_SOURCE}:$LINENO]> ${BASH_COMMAND}"')
+EXIT_HOOKS=()
 # @description
 # This is the actual function which is run on `trap EXIT`.
 # It iterates over all command lines added to `$EXIT_HOOKS` and performs the following steps to execute each:
 # 1. Split up the string 'line' into an array of 'words'
 # 2. Run the array as command
 function _runExitHooks {
+  local scriptState="$?"
   local hook
-  for hook in "${EXIT_HOOKS[@]}"; do
+  local idx=0
+  while [ "$idx" -lt "${#EXIT_HOOKS[@]}" ]; do
+    hook="${EXIT_HOOKS[$idx]}"
     _logAndOutWhenDebug "exit cmd> $hook"
-    eval "$hook"
+    # all hooks must run, even when -e is set, as long as they don't directly contain `exit`
+    eval "$hook" || true
+    let ++idx
   done
 }
 trap _runExitHooks EXIT
+
+set -eE
+trap '_logAndOut "$(_callstack "Failed at [${BASH_COMMAND}]")"' ERR
 
 # @endsection
 
@@ -529,7 +537,7 @@ function _readGameLaunchConfig {
       --options "declareCommand=declare-ro" "keyPrefix=$propertyPrefix" \
   ) || return 1
 
-  local cmdVarName="$propertyPrefixCMD"
+  local cmdVarName="${propertyPrefix}CMD"
   _explode "$cmdVarName" "${!cmdVarName}"
 }
 
@@ -564,7 +572,7 @@ function _setupPrefix {
   if [ "$2" = "--no-config" ]; then
     return 0
   fi
-  GAME_PREFIX="$PREFIX"
+  export GAME_PREFIX="$PREFIX"
   if _hasFunc _readGameLaunchConfig; then
     _readGameLaunchConfig || _interface:errorAbort "Failed to read/prepare game config."
   fi

--- a/sources/fs-root/opt/batocera-emulationstation/lib/logging.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/logging.lib
@@ -25,16 +25,16 @@ function _logOnly {
 
 _hasFunc _logAndOut || \
 function _logAndOut {
-  _logOnly "$@"
   local RET="$?"
+  _logOnly "$@" || true
   if echo "$@" >&2; then return "$RET"; fi
 }
 
 _hasFunc _logAndOutWhenDebug || \
 function _logAndOutWhenDebug {
   local RET="$?"
+  _logOnly "$@"
   if [ -n "$PRINT_DEBUG" ]; then
-    _logOnly "$@"
     if echo "$@" >&2; then return "$RET"; fi
   fi
   return "$RET"
@@ -42,22 +42,33 @@ function _logAndOutWhenDebug {
 
 _hasFunc _pipeDebugLog || \
 function _pipeDebugLog {
-  local RET="$?"
   if [ -n "$PRINT_DEBUG" ]; then
-    if tee -a "$LOGFILE" >&2; then return "$RET"; fi
+    tee -a "$LOGFILE" >&2
   else
-    if cat >&3; then return "$RET"; fi
+    cat >&3
   fi
 }
+
+_hasFunc _printException || \
+# @description
+# Print a message, followed by a full stack trace. Trace starts just below `_printException`.
+# @arg $1 string Message to print 
+# @arg $2 string (optional) print function to use (default: _logAndOut") 
+function _printException {
+  local _msg="$1"
+  local _printer="${2:-_logAndOut}"
+  "$_printer" "$(_callstack "$_msg" 1)"
+} 
 
 _hasFunc _callstack || \
 # @description Generate a call stack similar to how it is done in higher languages.
 # @arg $1 message to print first (optional)
+# @arg $2 int number of top level stack entries to skip. Useful when `_callstack` is called directly from within other helpers.
 # @stdout generated stack 
 function _callstack {
   [ -z "$1" ] || printf '%s\n' "$1"
 
-  local idx="0"
+  local idx="${2:-0}"
   while [ -n "${BASH_LINENO[$idx]}" ]; do 
     local _line="${BASH_LINENO[$idx]}"
     local _file="${BASH_SOURCE[$idx+1]}"

--- a/test/js/libs/import.test.js
+++ b/test/js/libs/import.test.js
@@ -20,7 +20,7 @@ const importer = require('config-import');
 function logDiff(file) {
   LOGGER.error(
     `Unexpected diff in [${file}]:\n`,
-    execSync(`git diff "${file}"`, { encoding: 'utf8' }) || ' -> not under version control'
+    execSync(`git diff -- "${file}"`, { encoding: 'utf8' }) || ' -> not under version control'
   )
 }
 

--- a/test/shell/opt/batocera-emulationstation/lib/launcher-base.lib.test.js
+++ b/test/shell/opt/batocera-emulationstation/lib/launcher-base.lib.test.js
@@ -2,6 +2,11 @@ const { ShellTestRunner } = require('js/utils/shelltest.mjs');
 
 enableLogfile();
 
+function assertFirstLine(fullMsg, expected){
+  let lines = fullMsg.split('\n');
+  assert.equal(lines[0] || '', expected);
+}
+
 const FILE_UNDER_TEST = 'opt/batocera-emulationstation/lib/launcher-base.lib';
 
 const EXPECTED_HELP = `--- Usage: ---
@@ -106,7 +111,7 @@ class LauncherBaseApiTest extends ShellTestRunner {
     let expectedLower = `${template}:/TEST`;
     let overlayArg = `lowerdir=${expectedLower},upperdir=${saveData},workdir=${workDir}`
     this.verifyFunction('fuse-overlayfs', '-o', overlayArg, gamePrefix);
-    this.verifyVariable('EXIT_HOOKS', ['.*', `_delayerUserSave '${saveDir}'`]);
+    this.verifyVariable('EXIT_HOOKS', [`_delayerUserSave '${saveDir}'`]);
 
     this.postActions(
       'mkdir "$_templatePrefix"',


### PR DESCRIPTION
- introduced `_requireVars` to make sure named variables exist
- change in behaviour of logging function exit status propagation
- make config import test's usage of git more robust
- `launcher-base`:
    * rework exit hook handling to allow late additions
    * run script with `set -eE` to get proper handling of unexpected issues, including a proper stack
    * fixed some variable exports and resolutions