### PR TITLE
[emulatorlauncher] generic improvements to launch + log

### DIFF
--- a/sources/fs-root/opt/batocera-emulationstation/lib/generic-utils.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/generic-utils.lib
@@ -31,6 +31,21 @@ function _hasFunc {
 }
 export -f _hasFunc
 
+# @description Remove double and trailing / slashes from the content of the variable given.  
+# Contrary to realpath, which performs a similar canonicalization, this does not follow links 
+# and it will also not convert relative to absolute paths.  
+# Only the slashes will be deduplicated.
+# @arg $1 variable name 
+function _sanitizePath {
+  local _extglob=($(shopt -p extglob || true))
+  shopt -s extglob
+  declare -n p="$1"
+  p="${p//+(\/)/\/}"
+  p="${p%+(/)}"
+  "${_extglob[@]}" || true
+}
+export -f _sanitizePath
+
 # @description join multiple strings into one, separated by the first argument given
 # uses IFS internally, so it will only take the first character of $1 even when the string is longer
 # @arg $1 character to use as separator
@@ -86,7 +101,7 @@ export -f _containsKey
 function _requireVars {
   while [ -n "$1" ]; do
     declare -n required="$1"
-    required="${required?$1}"
+    required="${required:?$1}"
     shift
   done
 }

--- a/sources/fs-root/opt/batocera-emulationstation/lib/launcher-base.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/launcher-base.lib
@@ -96,6 +96,7 @@
 #|    - `_fileEnding`
 #|    - anything declared in `handleType_"${type_group|_fileEnding}"`
 #|    - anything declared in [_postConfig](#_postconfig)
+#|    - `_templatePrefix` will have `~` at beginning resolved to `HOME`
 #|    - `LIB_DIR`
 #|    - `GAME_SAVE_DIR`
 # 3. [handleType_dir](#handletype_dir)
@@ -409,11 +410,12 @@ function main {
   if _hasFunc _postConfig; then
     _postConfig
   fi
+  _templatePrefix="${_templatePrefix/\~/"$HOME"}"
   LIB_DIR=${LIB_DIR:-"$ROMS_ROOT_DIR/$relativeRomPath"}
   GAME_SAVE_DIR=${GAME_SAVE_DIR:-"$SAVES_ROOT_DIR/$relativeRomPath"}
   
   # run the action
-  _logAndOut "running $_action"
+  _logAndOut "executing action: $_action"
   "$_action"
 }
 
@@ -720,7 +722,7 @@ function _initUserFromLib {
 
   mkdir -p "$GAME_SAVE_DIR"/save_data
   fuse-overlayfs \
-    -o "lowerdir=${lowerdirs},upperdir=${GAME_SAVE_DIR}/save_data,workdir=${GAME_SAVE_DIR}/workdir" \
+    -o "lowerdir=${lowerdirs:?required},upperdir=${GAME_SAVE_DIR}/save_data,workdir=${GAME_SAVE_DIR}/workdir" \
     "$GAME_PREFIX"
   EXIT_HOOKS+=("_delayerUserSave '$GAME_SAVE_DIR'")
 }

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-paths.lib
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-paths.lib
@@ -6,7 +6,9 @@
 # It is required because almost any path used in the code can be adjusted and re-configured, both system-wide as well as
 # user-specific paths.    
 # The following definitions are made in this file:
-# - `XDG_*` - runtime, config, data, state, cache 
+# - `XDG_*` - runtime, config, data, state, cache
+# - `XDG_HOME` - special variable to quickly relocate all XDG dirs (except runtime) (default $HOME).  
+#    The subdirectory path of each variable will be as it normally is for HOME.
 # - `ES_DATA_DIR`, `ES_STATE_DIR`, `ES_CACHE_DIR`
 # - `ROMS_ROOT_DIR`
 # - `SAVES_ROOT_DIR`
@@ -24,10 +26,11 @@
 
 # make sure all XDG variables are defined and exported
 XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/var/run/user/$(id -u)}
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$(realpath -s "$HOME"/.config)}
-XDG_DATA_HOME=${XDG_DATA_HOME:-$(realpath -s "$HOME"/.local/share)}
-XDG_STATE_HOME=${XDG_STATE_HOME:-$(realpath -s "$HOME"/.local/state)}
-XDG_CACHE_HOME=${XDG_CACHE_HOME:-$(realpath -s "$HOME"/.cache)}
+XDG_HOME=${XDG_HOME:-$(realpath -s "$HOME")}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$(realpath -s "$XDG_HOME"/.config)}
+XDG_DATA_HOME=${XDG_DATA_HOME:-$(realpath -s "$XDG_HOME"/.local/share)}
+XDG_STATE_HOME=${XDG_STATE_HOME:-$(realpath -s "$XDG_HOME"/.local/state)}
+XDG_CACHE_HOME=${XDG_CACHE_HOME:-$(realpath -s "$XDG_HOME"/.cache)}
 export XDG_RUNTIME_DIR XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_CACHE_HOME
 
 export ES_HOME=${ES_HOME:-$(realpath -s "$HOME")}

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/utils/path.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/utils/path.js
@@ -1,6 +1,8 @@
 
 const { isAbsolute, resolve, extname, basename, relative } = require('node:path');
 const { existsSync, realpathSync } = require('node:fs');
+const data = require('utils/data');
+
 const log = require('logger').get();
 
 const USER_SYSTEM_CONFIGS = `"${getConfigHome()}"/es_systems*.cfg`
@@ -98,7 +100,9 @@ function readSystemRomPaths(...fileGlobs) {
   if (fileGlobs.length == 0) { fileGlobs.push(USER_SYSTEM_CONFIGS) }
   let { execSync } = require('node:child_process');
   let { XML } = require('io/parsers');
-  let fullSource = XML.removeComments(execSync(`shopt -s nullglob; /bin/cat ${fileGlobs.join(' ')}`, { encoding: 'utf8' })).join('\n');
+  let sourceLoader = `shopt -s nullglob; /bin/cat ${fileGlobs.join(' ')}`;
+  let fullSource = XML.removeComments(execSync(sourceLoader, { encoding: 'utf8', shell: '/bin/bash' })).join('\n');
+  if (data.isEmpty(fullSource)) throw new Error(`No es_systems found with glob(s) [${fileGlobs.join(' ')}]`);
   let systems = execSync(`${SYSTEMS_GREP}`, { encoding: 'utf8', input: fullSource }).split('<system>');
 
   let sysPathMappings = {};

--- a/sources/fs-root/usr/bin/emulatorlauncher
+++ b/sources/fs-root/usr/bin/emulatorlauncher
@@ -48,7 +48,7 @@ if [ "$#" -lt 2 ] || [ "$1" = "--help" ]; then
   exit 0
 fi
 
-source "$SH_LIB_DIR"/logging.lib ~/emuLaunch.log
+source "$SH_LIB_DIR"/logging.lib "$ES_STATE_DIR"/emulatorlauncher.log
 source "$SH_LIB_DIR"/amx.lib
 source "$SH_LIB_DIR"/interaction_helpers.lib
 
@@ -150,7 +150,7 @@ function declare-ro {
 # certain well-known default locations will be prepended and checked for existence.
 # @arg $1 path to file
 function _sourceLib {
-  _logOnly "sourcing file: '$1'"
+  _logAndOutWhenDebug "sourcing file: '$1'"
   if [ -e "$1" ]; then
     source "$1" || exit 1
   elif [ -e "$EL_PKG_DIR/lib/$1" ]; then
@@ -280,8 +280,7 @@ for cfg in "${_emuConfigs[@]}"; do
 done
 
 if [ -z "$launchCommand" ]; then
-  _logAndOut "No configuration with a valid launchCommand found for [s:$system, e:$emulator, c:$core]. Exiting"
-  exit 1
+  _interface:errorAbort "No configuration with a valid launchCommand found for [s:$system, e:$emulator, c:$core]. Exiting"
 fi
 # END BLOCK
 

--- a/test/js/utils/shelltest.mjs
+++ b/test/js/utils/shelltest.mjs
@@ -23,7 +23,7 @@ const SHELL_EXIT_HANDLER = `
 function _callstack {
   [ -z "$1" ] || builtin printf '%s\\n' "$1"
 
-  local idx="0"
+  local idx="\${2:-0}"
   while [ -n "\${BASH_LINENO[$idx]}" ]; do 
     local _line="\${BASH_LINENO[$idx]}"
     local _file="\${BASH_SOURCE[$idx+1]:-stdin}"

--- a/test/shell/opt/batocera-emulationstation/lib/generic-utils.lib.test.js
+++ b/test/shell/opt/batocera-emulationstation/lib/generic-utils.lib.test.js
@@ -90,6 +90,35 @@ class GenericUtilsTests extends ShellTestRunner {
     this.execute();
   }
 
+  _requireVars() {
+    this.postActions(
+      'declare TEST_VAR=ABC NOT_THERE=',
+      '_requireVars TEST_VAR',
+      '_requireVars NOT_THERE'
+    );
+    this.throwOnError = false;
+    this.execute();
+    assert.match(this.result.stderr, /.*generic-utils.lib.*?line.*required: NOT_THERE/);
+  }
+
+  _sanitizePath() {
+    let values = {
+      REL_NORMAL: './something',
+      REL_DOUBLES: './/something///',
+      ABS_NORMAL: '/fs/root/path',
+      ABS_DOUBLES: '//fs/root////path/'
+    };
+    this.environment(values);
+    this.postActions(...Object.keys(values).map(_ => `_sanitizePath ${_}`));
+    this.execute();
+
+    this.verifyVariables({
+      REL_NORMAL: values.REL_NORMAL,
+      REL_DOUBLES: values.REL_NORMAL,
+      ABS_NORMAL: values.ABS_NORMAL,
+      ABS_DOUBLES: values.ABS_NORMAL
+    })
+  }
 }
 
 runTestClasses(FILE_UNDER_TEST, GenericUtilsTests)

--- a/test/shell/opt/batocera-emulationstation/lib/user-paths.lib.test.js
+++ b/test/shell/opt/batocera-emulationstation/lib/user-paths.lib.test.js
@@ -14,7 +14,7 @@ class UserPathsTest extends ShellTestRunner {
     this.verifyFunction('mkdir');
   }
 
-  verifyXdgDirs() {
+  verifyXdgDirsHOME() {
     this.environment({
       HOME: this.TMP_DIR,
       XDG_RUNTIME_DIR: '/dev/null'
@@ -25,6 +25,21 @@ class UserPathsTest extends ShellTestRunner {
       XDG_DATA_HOME: this.TMP_DIR + '/.local/share',
       XDG_STATE_HOME: this.TMP_DIR + '/.local/state',
       XDG_CACHE_HOME: this.TMP_DIR + '/.cache',
+    });
+    this.execute();
+  }
+
+  verifyXdgDirsXDG_HOME() {
+    this.environment({
+      XDG_HOME: this.TMP_DIR + '/xdg',
+      XDG_RUNTIME_DIR: '/dev/null'
+    });
+    this.verifyVariables({
+      XDG_RUNTIME_DIR: '/dev/null',
+      XDG_CONFIG_HOME: this.TMP_DIR + '/xdg/.config',
+      XDG_DATA_HOME: this.TMP_DIR + '/xdg/.local/share',
+      XDG_STATE_HOME: this.TMP_DIR + '/xdg/.local/state',
+      XDG_CACHE_HOME: this.TMP_DIR + '/xdg/.cache',
     });
     this.execute();
   }


### PR DESCRIPTION
- make sure `emulatorlauncher` also writes its log file into `ES_STATE_DIR` instead of just using ~
- introduce generic shell util `_sanitizePath`
- add tests for several generic shell utils
- extended some error reporting when trying to get effective properties
- introduced non-spec optional convenience variable `XDG_HOME`, which will replace `HOME` when resolving XDG_ vars, but ONLY if set. Defaults to the value of `HOME`