### PR TITLE
Rework parsing of `YAML` and `XML` 1/2

### DIFF
--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -213,7 +213,6 @@ function xmlToDict(xmlFile) {
 
 function xmlNew(xmlFile) {
   let result = readTextPropertyFile(xmlFile, sourceText => {
-    let diag = false;
 
     let context = new ParseContext();
     context.addAttributeNode = function(m) {
@@ -235,12 +234,12 @@ function xmlNew(xmlFile) {
       VAL: [/(\S[^\<\>]*?)\s*(?=\<)/ms, m => context.addContent(handleValue(XML.decodeValue(m[1])), m[0])],
       // end of the node (closing tag)
       EON: [/<?\/[\p{L}\._\d-]*?>/msu, m => context.leaveNode(m[0])],
-    }, diag);
+    }, 'XML');
 
     sourceText = sourceText.replace(/\<\?.*?\?\>/gs, '');
     sourceText = sourceText.replace(/\<!--.*?--\>/gs, '');
 
-    context.start();
+    context.start(R);
     R.exec(sourceText);
 
     return context.current.valueOf();
@@ -312,10 +311,11 @@ function analyseProperty(propLine) {
  */
 class RegexDocParser extends RegExp {
   #id;
-  #diagMessages;
+  #log
+  #stackLog;
   #state;
-  #rules = false;
-  #ruleIds = false;
+  #rules = [];
+  #ruleIds = {};
   static #patchFlags(reg, flags) {
     flags ||= reg.flags;
     if (!flags.includes('y')) { flags += 'y'; }
@@ -323,10 +323,10 @@ class RegexDocParser extends RegExp {
     return flags;
   }
   static #escapeSpaces(str) { return str.replace(/\n/g, '\\n').replace(/\t/g, '\\t'); }
-  static #execRule(reg, action, useAllowed, sourceText, diag) {
+  static #execRule(reg, action, useAllowed, sourceText) {
+    this.currentRule = reg;
     if (!useAllowed()) { return false; }
-
-    let m = reg.exec(sourceText, diag);
+    let m = reg.exec(sourceText, false);
     if (m == null) { return false; }
     // skip empty matches
     if (m.indices[0][1] - m.indices[0][0] == 0) { return false; }
@@ -340,66 +340,101 @@ class RegexDocParser extends RegExp {
     let ruleIdx = 0;
     let lastRule = shared.#rules.length - 1;
     while (shared.lastIndex < sourceText.length) {
-      let ruleResult = shared.#rules[ruleIdx](sourceText, shared.#diagMessages);
+      let ruleResult = shared.#rules[ruleIdx](sourceText);
+      shared.currentRule = null;
       if (ruleResult) { ruleIdx = shared.#ruleIds[ruleResult] || 0; }
       else { ruleIdx++; }
 
-      if (ruleIdx > lastRule) {
-        let snippet = sourceText.slice(shared.lastIndex, shared.lastIndex + 20);
-        throw 'No valid expression for [' + JSON.stringify(snippet) + '...]';
-      }
+      if (ruleIdx > lastRule) { throw 'No valid expression for [' + this.snippet(sourceText) + ']'; }
     }
   }
+
+  #initParser(conf, id) {
+    this.#log = require('logger').get(id || RegexDocParser.name);
+    this.#log.excludeRules = [];
+    Object.keys(conf).forEach(k => {
+      if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
+      this[k] = new RegexDocParser(this, k, conf[k][0]);
+      this.#ruleIds[k] = this.#rules.length;
+      this.#rules.push(RegexDocParser.#execRule.bind(this, this[k], conf[k][1], conf[k][2] || (() => true)));
+    });
+    this.exec = function exec(str) { return RegexDocParser.#traverseSource(this, str); }.bind(this);
+    this.lastIndex = 0;
+    /* Not a real rule, it's placed like this to get access to the uniform log methods */
+    this.stack = new RegexDocParser(this, '%STACK', /.*/);
+  }
+
+  #initSubRule(parent, id) {
+    this.#state = parent;
+    this.#state.reset ||= this.reset.bind(this);
+    this.#id = id;
+    this.#log = this.#state.#log;
+  }
+
   constructor(state, id, a, b) {
     if (arguments.length <= 2) {
       super(/.*/);
-      this.#rules = [];
-      this.#ruleIds = {};
-      Object.keys(state).forEach(k => {
-        if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
-        this[k] = new RegexDocParser(this, k, state[k][0]);
-        this.#ruleIds[k] = this.#rules.length;
-        this.#rules.push(RegexDocParser.#execRule.bind(this, this[k], state[k][1], state[k][2] || (() => true)));
-      });
-      this.exec = function exec(str) { return RegexDocParser.#traverseSource(this, str); }.bind(this);
-      this.#diagMessages = id || false;
-      this.lastIndex = 0;
+      this.#initParser(state, id);
       return this;
     }
 
     super(a, RegexDocParser.#patchFlags(a, b));
-    this.#state = state;
-    state.reset ||= this.reset.bind(this);
-    this.#id = id;
+    this.#initSubRule(state, id);
   }
 
   getId() { return this.#id; }
   reset() { this.#state.lastIndex = 0; }
 
   exec(sourceText, diag) {
-    let currentLast = this.#state.lastIndex;
+    let currentLast = this.#state.lastIndex || 0;
     this.lastIndex = currentLast;
     let match = super.exec(sourceText);
-    diag = !['TRAIL'].includes(this.#id);
-    if (diag) {
-      let snippet = RegexDocParser.#escapeSpaces(sourceText
-        .substring(currentLast, currentLast + 30)
-      ).substring(0, 32).padEnd(35, '.');
-      match && console.error(
-        `[${this.#id.padStart(6)}] `,
-        `${snippet}`,
-        "=>",
-        '[' + RegexDocParser.#escapeSpaces((match || []).join('|')) + ']'
-      );
-    }
+
     if (match == null) { return null; }
+    this.logRule(
+      () => this.snippet(sourceText, currentLast)
+        + '=> [' + RegexDocParser.#escapeSpaces((match || []).join('|')) + ']'
+    )
     if (match.indices[0][0] != currentLast) {
-      diag && console.error(this.#id, "did not start at lastIndex=" + currentLast, ", but at", this.lastIndex);
+      this.logDetails(() => "SKIP: did not start at lastIndex=" + currentLast, ", but at", this.lastIndex);
       return null;
     }
 
     this.#state.lastIndex = this.lastIndex;
     return match;
+  }
+
+  get activeRule() {
+    if (this.#state) { return this; }
+    return this.currentRule || this;
+  }
+  #conditionalLog(level, suffix, ...data) {
+    let id = this.#state ? this.#id : null;
+    if (this.#log.excludeRules.includes(id || '%SELF')) { return; }
+    let prefix = id ? `[${id.padStart(6)}] ` : '';
+    if (suffix) { prefix += (suffix + ' '); }
+    let handler = typeof data[0] == "function" ? data[0] : () => data.join(' ');
+    this.#log.logWhen(level, () => prefix + handler());
+  }
+
+  /** 
+   * An array of rule ids, and/or special tags '%SELF' and '%STACK'.  
+   * Logs using `logRule` or `logDetails` from a rule will be supressed if a rule's id is contained in the exclude.  
+   * Partial overriding is possible by using `log` instead, but this can in turn be disabled by excluding `%SELF`.  
+   */
+  setLogExcludes(f = []) { this.activeRule.#log.excludeRules = f; }
+  /** Logs on INFO level and bound to `%SELF` topic instead of the rule id. */
+  log(...data) { (this.#state || this).#conditionalLog('INFO', '', ...data); }
+  /** Logs on DEBUG level */
+  logRule(...data) { this.activeRule.#conditionalLog('INFO', '', ...data); }
+  /** Logs on TRACE level  */
+  logDetails(...data) { this.activeRule.#conditionalLog('INFO', '   -->', ...data); }
+
+  /** Return a short part from the beginning of the given string, with breaks and tabs encoded. */
+  snippet(sourceText, startIndex) {
+    if (typeof startIndex != "number") { startIndex = this.lastIndex; }
+    let snippetRaw = sourceText.substring(startIndex, startIndex + 30);
+    return RegexDocParser.#escapeSpaces(snippetRaw).substring(0, 32).padEnd(35, '.');
   }
   toString() { return super.toString(); }
 }
@@ -428,6 +463,7 @@ class ParseContext {
   }
 
   start(parser) {
+    if (!parser) { throw 'parser argument required!'; }
     this.parser = parser;
     this.#STACK = [new UniversalNode('#root')];
   }
@@ -436,26 +472,29 @@ class ParseContext {
     let node = new UniversalNode(name, raw);
     this.current.subNode(name, node);
     this.#STACK.push(node);
-    console.error('\t--> ENTER', this.current.tagName)
+    this.parser.stack.logDetails('ENTER:', this.current.tagName);
   }
 
   addChildNode(tag) {
     let node = new UniversalNode(tag);
     this.current.content(node)
     this.#STACK.push(node);
-    console.error('\t--> PUSH CHILD:', tag)
+    this.parser.stack.logDetails('PUSH CHILD:', tag)
   }
 
   nodeHeaderDone(raw) { this.current.headerDone(raw); }
 
   // leave node
   leaveNode(raw) {
-    console.error('\t--> LEAVE', this.current.tagName, this.current)
+    this.parser.stack.logDetails('LEAVE:', this.current.tagName)
     this.current.addRaw(raw, true);
     this.#STACK.pop();
   }
 
-  addContent(text, raw) { this.current.content(text, raw); }
+  addContent(text, raw) {
+    this.parser.stack.logDetails(() => 'CONTENT: ' + JSON.stringify(text));
+    this.current.content(text, raw);
+  }
 }
 
 /**
@@ -606,9 +645,10 @@ function r(constants, ...paras) {
   return new RegExp(raw);
 }
 
+/** Used by `unquote` */
 const QUOTE_MATCHER = /^\s*(["'])(.*)\1\s*$/s
 /** 
- * Unquote any **content** string enclosed in either `"` or `'` and returns the true inner string value.  
+ * Unquotes any **content** string enclosed in either `"` or `'` and returns the true inner string value.  
  * By default, the character used to as quotation is also unmasked (if it is by an uneven number of \).  
  * Quote unmasking can be disabled by passing false as second parameter.
  */
@@ -694,8 +734,9 @@ class YAML extends ParseContext {
       'DPT:FL': [/(\n\s*)/, yaml.handleToken, isMode('FLOW')],
       // NOOP: trailing whitespace from payload up to the next \n
       TRAIL: [/([ \t]+)(?=\S|\n|$)/m, yaml.handleToken]
-    }, true);
+    }, 'YAML');
 
+    R.setLogExcludes(['TRAIL']);
     yaml.start(R);
     yaml.current[YAML.NESTING] = -1;
     yaml.current[YAML.MODE] = 'BLOCK';
@@ -719,9 +760,9 @@ class YAML extends ParseContext {
   inheritStateProperties() {
     this.current[YAML.MODE] = this.previous[YAML.MODE] || 'BLOCK';
     this.current[YAML.NESTING] = this.previous[YAML.CNEST] || 0;
-    console.error(
-      `\t--> INHERIT ${this.current.tagName}:`, this.current[YAML.NESTING], '->', this.current[YAML.MODE],
-      `from:`, this.previous.tagName, this.previous[YAML.NESTING], this.previous[YAML.CNEST]
+    this.parser.logDetails(
+      `INHERIT ${this.current.tagName}/${this.current[YAML.NESTING]} <-`,
+      `${this.current[YAML.MODE]}:${this.previous.tagName}/${this.previous[YAML.CNEST]}`
     );
   }
 
@@ -730,7 +771,7 @@ class YAML extends ParseContext {
     // when coming from parser directly, the first group will be token content
     // otherwise it could be called from another method with a pre-processed string
     match = Array.isArray(match) ? match[1] : match;
-    let token = (this.current[YAML.TOKEN] ||= new YamlToken(this.current));
+    let token = (this.current[YAML.TOKEN] ||= new YamlToken(this));
     if (token.isEmpty() && rule != null && ['DQ', 'SQ'].includes(rule.getId())) { token.quoteMode = rule.getId(); }
     token.add(match);
     switch (this.state(YAML.PHASE)) {
@@ -754,8 +795,6 @@ class YAML extends ParseContext {
   tokenToContent() {
     let token = this.consumeToken();
     if (typeof token == "undefined") { return }
-
-    console.error('\t--> ASSIGN TOKEN', token);
     this.addContent(new PropValue(token));
   }
 
@@ -777,7 +816,6 @@ class YAML extends ParseContext {
 
     this.finishCurrentNode();
     if (!this.previous) { return; }
-    console.error('\t    MODES (p,c)', this.previous[YAML.MODE], this.current[YAML.MODE])
     if (this.current.tagName == "#FLOW:ROOT") { this.finishCurrentNode(); }
   }
 
@@ -790,7 +828,8 @@ class YAML extends ParseContext {
       case '|':
       case '>':
         let tokenStyle = YAML.BLOCK_H_STYLES[op.charAt(0)];
-        let token = new YamlToken(this.current, tokenStyle);
+        let token = new YamlToken(this, tokenStyle);
+        token.parser = this.parser;
         this.state(YAML.TOKEN, token);
         token.chomping = YAML.CHOMP_MODES[op.replace(/[^+-]/g, '')];
         token.nesting = op.replace(/[^\d]/g, '');
@@ -799,7 +838,6 @@ class YAML extends ParseContext {
 
   markArray(depth, addChild = true) {
     depth = Number(depth) || 2;
-    console.error("\t--> MARK ARRAY:", this.current.tagName, 'N:', this.state(YAML.NESTING), 'CN:', this.current[YAML.CNEST]);
     if (this.current.getContentMode() != "ARRAY") {
       this.pushNextNode(this.current.tagName + '[]', false);
       this.state(YAML.NESTING, this.previous[YAML.NESTING]);
@@ -814,6 +852,7 @@ class YAML extends ParseContext {
   }
 
   finishCurrentNode() {
+    this.parser.logDetails('CLOSE:', this.current.tagName);
     this.tokenToContent();
     this.cleanNode();
     this.leaveNode();
@@ -823,10 +862,10 @@ class YAML extends ParseContext {
     node ||= this.current;
     if (value == undefined) { return node[state]; }
     node[state] = value;
-    console.error(`\t--> ${Symbol.keyFor(state)} ${value} >>> ${node.tagName}`)
+    this.parser.logDetails(`${Symbol.keyFor(state)} ${value} >>> ${node.tagName}`);
   }
 
-  /** Only SET value if state is not set already */
+  /** Only set value if state is not set already */
   stateOnce(state, value, node) {
     node ||= this.current;
     if (typeof value == "undefined") { throw "stateOnce() must receive a value argument" }
@@ -846,7 +885,7 @@ class YAML extends ParseContext {
         this.markArray(arrD - regD, false);
       }
       let diff = this.state(YAML.NESTING) - (this.current.getContentMode() == "ARRAY" ? arrD : regD);
-      console.error("\t--> RCL:" + this.current.tagName, 'N:', this.current[YAML.NESTING], 'D:', diff, regD, arrD)
+      this.parser.logDetails('RCL:' + this.current.tagName, 'N:', this.current[YAML.NESTING], 'D:' + diff, `(${regD}-${arrD})`);
 
       if (diff >= 0) { this.finishCurrentNode(depthMatch); }
       else { break; }
@@ -873,20 +912,23 @@ class YamlToken {
   static JSON_MASKING = { '\n': '\\n', '\t': '\\t' }
 
   #style = 'FLOW'; //FLOW, (Block-)FOLD or (Block-)LITERAL
-  #quoting = 'NQ'; // DQ, SQ, NQ; for FLOW only
-  #chompMode = 'CLIP'; // STRIP, CLIP, KEEP
+  #quoting = 'NQ';
+  #chompMode = 'CLIP';
   #indent;
 
-  #token;
+  #token = '';
   #trailing;
 
-  constructor(parentNode, style) {
-    this.parent = parentNode;
+  constructor(context, style) {
+    this.parser = context.parser;
+    this.parent = context.current;
     this.#style = style || this.#style;
   }
   isEmpty() { return (typeof this.#token == "undefined") || this.#token.trim().length == 0; }
 
+  /** @arg {"CLIP"|"STRIP"|"KEEP"} style */
   set chomping(style) { this.#chompMode = style; }
+  /** @arg {"DQ"|"SQ"|"NQ"} mode sets quoting for "FLOW" style tokens */
   set quoteMode(mode = "NQ") { this.#quoting = mode; }
   set indentation(raw) {
     let n = parseInt(raw);
@@ -907,11 +949,11 @@ class YamlToken {
   }
 
   add(text) {
-    this.#token ||= '';
+    this.parser.logDetails(() => { return 'TOKEN-ADD: ' + JSON.stringify(text); });
     this.#token += text;
   }
 
-  /*
+  /**
    * Applies the configuration / string styles to convert the raw token into a yaml value, then returns the result.  
    *
    * To do so, the content must first be concatenated, then modified in 5 locations/steps, in the order below:
@@ -926,7 +968,7 @@ class YamlToken {
    *   d) assume string for everything else
   */
   get() {
-    console.error("\t--> GET-TK:", this.#style, this.#quoting, this.indentation, this.#chompMode, '\n', JSON.stringify(this.#token));
+    this.parser.logDetails('TOKEN-GET:', this.#style, this.#quoting, this.indentation, this.#chompMode, 'RAW:', JSON.stringify(this.#token));
     if (this.isEmpty()) { return; }
 
     // 1. Basic normalization and structural cleaning

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -860,20 +860,48 @@ function unquote(value, unmask=true){
   else { return matched[2]; }
 }
 
-/** Encapsulates transformation of a sequence of raw string tokens into one single string instance, folded, trimmed and chomped where needed. */
-class YamlString {
-  #token;
+/** 
+ * Encapsulates transformation of raw (multiline) tokens into the corresponding final output value.
+ * - It handles all folding, trimming and chomping for styles of strings.
+ * - One-word unquoted tokens will be evaluated as JSON primitives with string as fallback on failure.
+ *
+ * **API:**  
+ * 1. token style is set in constructor, must be one of (`FLOW`, (Block-)`FOLD` or (Block-)`LITERAL`)
+ * 2. `YamlToken.quoteMode` is for flow and must be one of (`DQ`, `SQ` or `NQ`).
+ * 3. (optional) `YamlToken.indentation` and `YamlToken.chomping` (`STRIP`, `CLIP` or `KEEP`) are for values coming from block headers.
+ * 4. Incrementally add raw input with `YamlToken.add(str)`. For flow tokens, the quote characters **must** be part of the raw input.
+ * 5. When done, retrieve the value with `YamlToken.get()`.
+ */
+class YamlToken {
+  static JSON_MASKING = {
+    '\n': '\\n',
+    '\t': '\\t'
+  }
   #style = 'FLOW'; //FLOW, (Block-)FOLD or (Block-)LITERAL
+  #quoting = 'NQ'; // DQ, SQ, NQ; for FLOW only
+  #chompMode = 'CLIP'; // STRIP, CLIP, KEEP
 
-  constructor(parentNode) { this.parent = parentNode; }
-  isEmpty() { return this.#token.trim().length == 0; }
+  #token;
+  #trailing;
+
+  constructor(parentNode, style) { 
+    this.parent = parentNode; 
+    this.#style = style;
+  }
+  isEmpty() { return (typeof this.#token == "undefined") || this.#token.trim().length == 0; }
+
+  set chomping(style){ this.#chompMode = style; }
+  set quoteMode(mode = "NQ") { this.#quoting = mode; }
 
   get shiftLevel() {
     if (this.#style == "FLOW") { return '+' }
     if (typeof this.indentation == "number") { return this.parent[YAML.NESTING] + this.indentation; }
-    let m = null;
-    if ((m = /(?<=^|\n)[ \t]*(?=\S)/.exec(this.#token)) != null) { return m[0].length; }
 
+    // YAML 1.2.2 - 8.1.1.1 Block Indentation Indicator
+    let m = null;
+    // 1. whitespace prefix of first none-empty line
+    if ((m = /(?<=^|\n)[ \t]*(?=\S)/.exec(this.#token)) != null) { return m[0].length; }
+    // 2. Longest empty line
     return Math.max(0, ...this.#token.split('\n').map(l => l.length));
   }
 
@@ -883,47 +911,145 @@ class YamlString {
   }
 
   /*
-   * Applies the configuration / string styles to convert the raw array into a string, then returns the result.  
+   * Applies the configuration / string styles to convert the raw token into a yaml value, then returns the result.  
    *
-   * To do so, the content must first be concatened, then modified in 4 locations, in the order below:
-   * 1. Remove 'structural' whitespace: Remove a number of blanks matching the indentation from the start of every line (a.k.a. 'shifting').
-   * 2. FOLD/FLOW: Remove trailing whitespaces per line and reduce subsequent empty lines by one.
-   * 3. Trailing whitespace AFTER content. Trimmed or chomped.
-   * 4. LITERAL: Keep shifted pre-content empty lines, trim in other styles.
+   * To do so, the content must first be concatenated, then modified in 5 locations/steps, in the order below:
+   * 1. Remove 'structural' whitespace: Remove a number of blanks from the start of every line (='shift').
+   * 2. FOLD/FLOW: Remove trailing whitespaces per line and reduce subsequent empty lines by one (='squash').
+   * 3. LITERAL: Keep shifted pre-content empty lines, trim in other styles.
+   * 4. Trailing whitespace AFTER content: Trim or chomp.
+   * 5. After sanitization, the content must be processed:
+   *   a) When DQ -> JSON.parse to handle escapes
+   *   b) SQ: remove outer '
+   *   c) unquoted, one-word values: try JSON.parse for numbers/boolean, return as string on error.
+   *   d) assume string for everything else
   */
   get() {
     if (this.isEmpty()) { return; }
 
-    let result = this.#token.replaceAll(/\r/g, '');
-
-    // 1. structural whitespace. In FLOW style, this includes ALL whitespace at a line's start
-    // for other styles, it depends on indentation and block header (handled by `get shiftLevel`)
-    let shiftLevel = this.shiftLevel.replace(/(\d+)/, '{$1}');
-    result = result.replace(r`/(?<=\n)[ \t]${shiftLevel}(?=\S)/g`, '');
+    // 1. Basic normalization and structural cleaning
+    let result= this.#sanitizedToken();
 
     // 2. Folding - the most confusing part of string handling
     // It's different between FLOW and (Block-)FOLD, and FOLD also has a list of execeptions when
     // strings are NOT folded (which are very confusing and contradictory)
     if (this.#style == "FLOW") {
-      // first remove whitespace before and after content in FLOW
-      result = result
-        .replace(/(?<=^|\n)[ \t]+(?=\S)/g, '')
-        .replace(/(?<=\S)[ \t]+(?=\n|$)/g, '');
+      result = this.#prepareFlow(result);
+    } else if (result.charAt(0) == '\n') {
+      // BLOCK headers must consume the very first `\n`, it is NOT part of the string.
+      // This line assumes that the parser does not consume linebreaks when evaluating the header,
+      // but rather includes them into whitespace when building the token (by pattern `DPT`).
+      result = result.substring(1);
     }
-    if (this.#style != "LITERAL") {
-      // now to the actual folding: convert singular \n between none-spaces to blanks
-      result = result.replace(/(?<=\S)\n(?=\S)/g, ' ');
-      // block folding has a set of special exceptions which can't fully be covered by regex on \n alone
-      // the hardest one is \n and empty lines following an indented line, which are not trimmed at all
-      // this will be handled by ADDING an additional \n at the right place (which will be stripped)
-      // by the next step again
-      if (this.#style == "FOLD") {
-        result = result.replace(/((^|\n)[ \t]+.*?\S[ \t]*\n)(\s*\n)(?![ \t])/g, '$1\n$3');
-      }
-      // remove \n which is followed by empty lines
-      result = result.replace(/(?<=\S)\n(\n+)(?!\s)/g, '$1');
+    // 3. Squashing of empty lines
+    if (this.#style != "LITERAL") { result = this.#handleFolding(result); }
+    // 4. Chomp
+    switch(this.#chompMode){
+      case 'CLIP': result += this.#trailing.length > 0 ? '\n' : ''; break;
+      case 'KEEP': result += this.#trailing; break;
     }
-    return unquote(result);
+    return this.#postProcess(result);
+  }
+
+  /**
+   * Peforms 3 actions on `#token` and returns the result:
+   * 1. Basic normalizations of encoding (`NFC`) and linebreaks (= drop `\r`)
+   * 2. Drop a number of (structural) whitespace characters at the beginning of each line.  
+   *    For flow tokens, all none-content spaces are dropped.  
+   *    For blocks, it depends on the indentation (and header).  
+   *    This step is elementary for the following logic, because it converts the yaml definition of an 'empty line'
+   *    into a plain, solitary `\n`. Any space or tab left after this is **content**.  
+   *    Subsequent logic won't have to deal with 'empty lines', so folding is mostly identical for FLOW and FOLD.
+   * 3. **Empty** trailing newlines are removed and stashed away into `#trailing`
+   */
+  #sanitizedToken(){
+    let result = this.#token.normalize('NFC').replaceAll(/\r/g, '');
+
+    // Structural whitespace
+    let shiftLevel = String(this.shiftLevel).replace(/(\d+)/, '{0,$1}');
+    let shiftReg = r`/(?<=^|\n)[ \t]${shiftLevel}/g`;
+    result = result.replaceAll(shiftReg, '');
+
+    //stash and drop trailing lines from the last content char (last character which is NOT `\n`) to end of string
+    this.#trailing = /(?<!\n)(\n*)?$/.exec(result)[1] || '';
+    if(this.#trailing.length > 0){ result = result.slice(0, -this.#trailing.length); }
+
+    return result;
+  }
+
+  /**
+   * Do some preparation specific to `FLOW` tokens.  
+   * Depending on quoting style:
+   * - DQ: Strip escaped newlines
+   * - SQ: Unescaped `''` by de-duplicating it.
+   * - NQ: completely drop any whitespace (including newlines) **before** the content
+   *
+   * Always: Strip all leading and trailing whitespace (spaces and tabs) on each line.
+   */
+  #prepareFlow(result) {
+    this.#chompMode = "STRIP";
+    switch(this.#quoting){
+      // Drop 'escaped' `\n` - these are yaml helpers to break the source without adding LFs to content.
+      // Other escape sequences will be dealt with by `JSON.parse(...)`,
+      // which is why the " surrounding the string must not be removed.
+      case 'DQ': result = result.replace(/\\\n/g, ''); break;
+      // Un-escape singular content apostrophs.
+      case 'SQ': result = result.replace(/''/g, "'"); break;
+      // `trimStart()` is only necessary when not quoted, whitespace outside of quotes will be dropped later.
+      // When the string doesn't start with a quote char, it's an unquoted token containing " or ' as content.
+      case 'NQ': default: result = result.trimStart();
+    }
+    // YAML 1.2.2 - 6.5. Line Folding - Flow Folding:
+    // remove whitespace before and after line content
+    return result
+      .replace(/(?<=^|\n)[ \t]+(?=\S)/g, '')
+      .replace(/(?<=\S)[ \t]+(?=\n|$)/g, '');
+  }
+
+  /**
+   * 1. Convert singular newlines to spaces
+   * 2. Squash subsequent newlines (and 'empty' lines) where applicable (some exception for block in `FOLD` style)
+   */
+  #handleFolding(result){
+    // YAML 1.2.2 - (Block Scalar) 8.1.3. Folded Style
+    // Deal with the none-folded exceptions by ADDING an additional `\n`, which will be stripped by the next step again.
+    // This is easier to detect than excluding the exceptions from the generic line folding used below.
+    if (this.#style == "FOLD") {
+      //A line starting with at least one space, which is followed by (at least) one empty line
+      result = result.replace(/(?<=^|\n)([ \t].*?\n)(\n+)(?!\n)/g, '$1\n$2');
+    }
+    // YAML 1.2.2 - 6.5. Line Folding
+    return result
+      // 1. Convert singular `\n` between none-spaces to blanks (implicitely excludes the FOLD-exception `\n[space]`).
+      .replace(/(?<=\S)\n(?=\S)/g, ' ')
+      // 2. Remove one `\n` which is followed by (at least one) empty line(s)
+      .replace(/(?<!^)\n(\n+)(?![ \t])/g, '$1');
+  }
+
+  #jsonMask(string, subs = YamlToken.JSON_MASKING){
+    let exp = r`/(${Object.keys(subs).join('|')})/g`
+    return string.replace(exp, (f)=>subs[f]) 
+  }
+
+  /**
+   * `FLOW` tokens are interpreted differently, based on their quoting style. This method takes care of that.
+   * - `DQ` supports backslash escapes
+   * - `SQ` are literal strings, but the outer ' must be stripped, as these are **not** content.
+   * - `NQ` might be JSON primitives (booleans, numbers, null).
+   */
+  #postProcess(result){
+    // blocks of any kind are strings, there is no clever evaluation of content or handling of quotes
+    if(this.#style != 'FLOW') { return result; }
+    result = result.trim();
+    switch(this.#quoting){
+      // If it has any whitespace, it's a string. If not, fallthrough as it might be another JSON primitive.
+      case 'NQ': if(/\s/.test(result)) { return result; }
+      // Double-quoted is parsed as JSON for backslash sequences, fallback to just unquoting on failure
+      case 'DQ': try{ return JSON.parse(this.#jsonMask(result)); } catch { /* ignore */ };
+      // Single-quoted doesn't support escapes other than '' which is handled in `#prepareFlow()`, so just unquote
+      case 'SQ': result = unquote(result, result.startsWith('"'));
+    }
+    return result;
   }
 }
 

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -37,8 +37,8 @@ const PARSE_FUNCTIONS = Object.freeze({
   'conf': confToDict,
   'json': jsonToDict,
   'cfg': esSettingsToDict,
-  'xml': xmlToDict,
-  'amgp': xmlToDict
+  'xml': xmlNew,
+  'amgp': xmlNew
 });
 
 const CONTENT_PROVIDER = Object.freeze({
@@ -211,6 +211,43 @@ function xmlToDict(xmlFile) {
     : result;
 }
 
+function xmlNew(xmlFile) {
+  let result = readTextPropertyFile(xmlFile, sourceText => {
+    let diag = false;
+    let context = new ParseContext();
+
+    let R = new RegexDocParser({
+      // none-node whitespace
+      BLK: [/\s+/ms, m => context.current.addRaw(m[0])],
+      // start of node
+      SON: [/<(?!\/)([\p{L}\._\d-]+?)([\s>]|(?=\/))/su, m => context.enterNode(m[1], m[0])],
+      //attribute
+      NATTR: [
+        /(\w+)=("[^"]*"|'[^']*')/s,
+        m => context.addAttr(m[1], handleValue(XML.decodeAttribute(m[2].slice(1, -1))), m[0])
+      ],
+      // end of node opening tag
+      EOH: [/\s*\>/ms, m => context.nodeHeaderDone(m[0])],
+      // node value/content
+      VAL: [/(\S[^\<\>]*?)\s*(?=\<)/ms, m => context.addContent(handleValue(XML.decodeValue(m[1])), m[0])],
+      // end of the node (closing tag)
+      EON: [/<?\/[\p{L}\._\d-]*?>/msu, m => context.leaveNode(m[0])],
+    }, diag);
+
+    sourceText = sourceText.replace(/\<\?.*?\?\>/gs, '');
+    sourceText = sourceText.replace(/\<!--.*?--\>/gs, '');
+
+    context.start();
+
+    R.exec(sourceText);
+
+    return context.current.valueOf();
+  }, CONTENT_PROVIDER.DIRECT, false);
+  return typeof result['NO-ROOT'] != "undefined"
+    ? result['NO-ROOT']
+    : result;
+}
+
 function yamlToDict(yamlFile) {
   return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
 }
@@ -337,16 +374,16 @@ class RegexDocParser extends RegExp {
       this.#rules = [];
       Object.keys(state).forEach(k => {
         if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
-        this[k] = new SharedStateRegEx(this, k, state[k][0]);
-        this.#rules.push(SharedStateRegEx.#execRule.bind(this, this[k], state[k][1]))
+        this[k] = new RegexDocParser(this, k, state[k][0]);
+        this.#rules.push(RegexDocParser.#execRule.bind(this, this[k], state[k][1]))
       });
-      this.exec = function exec(str) { return SharedStateRegEx.#traverseSource(this, str); }.bind(this);
+      this.exec = function exec(str) { return RegexDocParser.#traverseSource(this, str); }.bind(this);
       this.#diagMessages = id || false;
       this.lastIndex = 0;
       return this;
     }
 
-    super(a, SharedStateRegEx.#patchFlags(a, b));
+    super(a, RegexDocParser.#patchFlags(a, b));
     this.#state = state;
     state.reset ||= this.reset.bind(this);
     this.#id = id;
@@ -809,7 +846,7 @@ module.exports = {
   parseDict, analyseProperty,
   SOURCE_FILE,
   // expose the parse functions themselves for places where the type is know, but not matching the extension
-  confToDict, xmlToDict, yamlToDict, jsonToDict, esSettingsToDict,
+  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict,
   //for information/API puposes
   FORMATS,
   XML,

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -852,13 +852,12 @@ function r(constants, ...paras) {
 }
 
 /** YAML FILES */
-const SINGLE_QUOTED = /'(.*)'/;
-const DOUBLE_QUOTED = /"(.*)"/;
-function unquote(value) {
-  let quoted;
-  if ((quoted = SINGLE_QUOTED.exec(value)) != null) { value = quoted[1].replaceAll("\\'", "'") }
-  else if ((quoted = DOUBLE_QUOTED.exec(value)) != null) { value = quoted[1].replaceAll('\\"', '"') }
-  return value;
+const QUOTE_MATCHER = /^(["'])(.*)\1$/s
+function unquote(value, unmask=true){
+  let matched = QUOTE_MATCHER.exec(value);
+  if (matched == null) { return value; }
+  if(unmask) { return matched[2].replace(r`\\${matched[1]}`, matched[1]); }
+  else { return matched[2]; }
 }
 
 /** Encapsulates transformation of a sequence of raw string tokens into one single string instance, folded, trimmed and chomped where needed. */

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -236,8 +236,9 @@ function xmlNew(xmlFile) {
       EON: [/<?\/[\p{L}\._\d-]*?>/msu, m => context.leaveNode(m[0])],
     }, 'XML');
 
-    sourceText = sourceText.replace(/\<\?.*?\?\>/gs, '');
-    sourceText = sourceText.replace(/\<!--.*?--\>/gs, '');
+    sourceText = sourceText
+      .replace(/\<\?.*?\?\>/gs, '')
+      .replace(/\<!--.*?--\>/gs, '');
 
     context.start(R);
     R.exec(sourceText);
@@ -260,7 +261,7 @@ function yamlToDict_IMPL(yamlFile) {
 const FOLDER_SPEC = /^\w+(\.folder\[(".*?")\/?\]).*=.*/;
 const GAME_SPEC = /^\w+\[(".*?")\].*/;
 function analyseProperty(propLine) {
-  let fspath = []
+  let fspath = [];
   if (fspath = FOLDER_SPEC.exec(propLine)) {
     propLine = propLine.replace(fspath[1], '');
     fspath = ['folder', unquote(fspath[2])];
@@ -303,7 +304,7 @@ function analyseProperty(propLine) {
  * let ctx = new ParseContext();
  * let p = new RegexDocParser({
  *|  name : [ /pattern/flags, matchFunction(m){ ctx.doSomething(m) ... } ]
- * }, debugMatches)
+ * }, parserName)
  * 
  * p.exec(fullSource);
  * 
@@ -312,7 +313,6 @@ function analyseProperty(propLine) {
 class RegexDocParser extends RegExp {
   #id;
   #log
-  #stackLog;
   #state;
   #rules = [];
   #ruleIds = {};
@@ -350,7 +350,8 @@ class RegexDocParser extends RegExp {
   }
 
   #initParser(conf, id) {
-    this.#log = require('logger').get(id || RegexDocParser.name);
+    this.#id = id || RegexDocParser.name;
+    this.#log = require('logger').get(id);
     this.#log.excludeRules = [];
     Object.keys(conf).forEach(k => {
       if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
@@ -365,9 +366,9 @@ class RegexDocParser extends RegExp {
   }
 
   #initSubRule(parent, id) {
+    this.#id = id;
     this.#state = parent;
     this.#state.reset ||= this.reset.bind(this);
-    this.#id = id;
     this.#log = this.#state.#log;
   }
 
@@ -385,7 +386,7 @@ class RegexDocParser extends RegExp {
   getId() { return this.#id; }
   reset() { this.#state.lastIndex = 0; }
 
-  exec(sourceText, diag) {
+  exec(sourceText) {
     let currentLast = this.#state.lastIndex || 0;
     this.lastIndex = currentLast;
     let match = super.exec(sourceText);
@@ -404,6 +405,7 @@ class RegexDocParser extends RegExp {
     return match;
   }
 
+  /** @returns {RegexDocParser} */
   get activeRule() {
     if (this.#state) { return this; }
     return this.currentRule || this;
@@ -707,7 +709,7 @@ class YAML extends ParseContext {
     let R = new RegexDocParser({
       // NOOP: Comments - (at least) one whitespace followed by whatever up to the next \n.
       // only allowed while not in the middle of a multiline token, treat it as regular content otherwise
-      LC: [/(?:^|\s)+#.*?(?=$)/m, false, isPhase(["TOKEN:ML"], false)],
+      LC: [/(?:^|\n[ \t]*|[ \t]*)[#%].*?(?=$|\n)/, false, isPhase(["TOKEN:ML"], false)],
       // Empty lines
       EL: [/(\n[ \t]*)(?=\n|$)/, yaml.handleToken],
       'BL:ARR': [/(-)(?=\s)/, yaml.markArray, isMode('BLOCK')],
@@ -722,9 +724,9 @@ class YAML extends ParseContext {
       OP: [/([:?](?=[ \t\n]))/, yaml.handleOperator],
       // indicators/operators belonging to flow mode: [], {}, ','
       'FL:OP': [/\{|\[/, yaml.enterFlow],
-      'FL:X': [/\s*(?:,[ \t]*\}|,[ \t]*\]|[,\}\]])/, yaml.closeFlow, isMode('FLOW')],
+      'FL:X': [/\s*(?:,[ \t]*\}|,[ \t]*\]|[,}\]])/, yaml.closeFlow, isMode('FLOW')],
       // unquoted in FLOW mode has additional terminators `,`, `}` and `]`
-      'NQ:FL': [/(\S.*?)(?=[:?-]\s|[\]\},]|\s#|\n)/, yaml.handleToken, isMode('FLOW')],
+      'NQ:FL': [/(\S.*?)(?=[:?-]\s|[\]},]|\s#|\n)/, yaml.handleToken, isMode('FLOW')],
       // any unquoted one-liner, up to the first indicator or linebreak
       // note: might have issues at end of file - requires an additional space or \n
       NQ: [/(\S.*?)(?=[:?-]\s|\s#|\n|$)/, yaml.handleToken],
@@ -740,6 +742,7 @@ class YAML extends ParseContext {
     yaml.start(R);
     yaml.current[YAML.NESTING] = -1;
     yaml.current[YAML.MODE] = 'BLOCK';
+    yaml.current[YAML.PHASE] = 'ENTRY';
 
     R.exec(sourceText);
     yaml.closeNodes(["", ""]);
@@ -832,7 +835,7 @@ class YAML extends ParseContext {
         token.parser = this.parser;
         this.state(YAML.TOKEN, token);
         token.chomping = YAML.CHOMP_MODES[op.replace(/[^+-]/g, '')];
-        token.nesting = op.replace(/[^\d]/g, '');
+        token.indentation = op.replace(/[^\d]/g, '');
     }
   }
 
@@ -840,7 +843,6 @@ class YAML extends ParseContext {
     depth = Number(depth) || 2;
     if (this.current.getContentMode() != "ARRAY") {
       this.pushNextNode(this.current.tagName + '[]', false);
-      this.state(YAML.NESTING, this.previous[YAML.NESTING]);
       this.state(YAML.CNEST, this.previous[YAML.CNEST]);
       this.current.setContentMode("ARRAY");
     }
@@ -852,7 +854,7 @@ class YAML extends ParseContext {
   }
 
   finishCurrentNode() {
-    this.parser.logDetails('CLOSE:', this.current.tagName);
+    this.parser.logDetails('FINISH:', this.current.tagName);
     this.tokenToContent();
     this.cleanNode();
     this.leaveNode();
@@ -880,12 +882,15 @@ class YAML extends ParseContext {
       this.parser.lastIndex -= 2;
     }
     while (true) {
-      if (arrD > regD && arrD > this.state(YAML.NESTING) && "ENTRY" == this.state(YAML.PHASE)) {
+      if (arrD > regD && arrD > (this.state(YAML.NESTING) || 0) && "ENTRY" == this.state(YAML.PHASE)) {
         this.state(YAML.CNEST, regD);
         this.markArray(arrD - regD, false);
       }
-      let diff = this.state(YAML.NESTING) - (this.current.getContentMode() == "ARRAY" ? arrD : regD);
-      this.parser.logDetails('RCL:' + this.current.tagName, 'N:', this.current[YAML.NESTING], 'D:' + diff, `(${regD}-${arrD})`);
+      let c = this.current;
+      let diff = this.state(YAML.NESTING) - (c.getContentMode() == "ARRAY" ? arrD : regD);
+      this.parser.logDetails(
+        `RCL:${c.tagName} N:${c[YAML.NESTING]} D:${diff} (-${c.getContentMode() == "ARRAY" ? arrD : regD})`
+      );
 
       if (diff >= 0) { this.finishCurrentNode(depthMatch); }
       else { break; }
@@ -930,6 +935,7 @@ class YamlToken {
   set chomping(style) { this.#chompMode = style; }
   /** @arg {"DQ"|"SQ"|"NQ"} mode sets quoting for "FLOW" style tokens */
   set quoteMode(mode = "NQ") { this.#quoting = mode; }
+  /** @arg {string|number} raw */
   set indentation(raw) {
     let n = parseInt(raw);
     if (Number.isNaN(n) || n < 1) { this.#indent = undefined; }
@@ -968,7 +974,7 @@ class YamlToken {
    *   d) assume string for everything else
   */
   get() {
-    this.parser.logDetails('TOKEN-GET:', this.#style, this.#quoting, this.indentation, this.#chompMode, 'RAW:', JSON.stringify(this.#token));
+    this.parser.logDetails('TOKEN-GET:', this.#style, this.#quoting, this.shiftLevel, this.#chompMode, 'RAW:', JSON.stringify(this.#token));
     if (this.isEmpty()) { return; }
 
     // 1. Basic normalization and structural cleaning

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -277,6 +277,201 @@ function analyseProperty(propLine) {
 }
 
 /**
+ * @section Generic parser infrastructure
+ */
+
+/**
+ * A configurable generic parser based on regular expressions.  
+ * The expressions will be set up to be sticky and share the same value for `lastIndex`.
+ * Any successful match of one of the sub-expressions will advance the shared state,
+ * but only when the match starts at the current `lastIndex`. It is not allowed to implicitely
+ * skip and ignore parts of the input.
+ * This allows to parse a long text without having to manipulate the input all the time 
+ * which greatly improves speed. There is also no need to split line by line.  
+ * 
+ * Usage:
+ * ```js
+ * let ctx = new ParseContext();
+ * let p = new RegexDocParser({
+ *|  name : [ /pattern/flags, matchFunction(m){ ctx.doSomething(m) ... } ]
+ * }, debugMatches)
+ * 
+ * p.exec(fullSource);
+ * 
+ * ```
+ */
+class RegexDocParser extends RegExp {
+  #id;
+  #diagMessages;
+  #state;
+  #rules = false;
+  static #patchFlags(reg, flags) {
+    flags ||= reg.flags;
+    if (!flags.includes('y')) { flags += 'y'; }
+    if (!flags.includes('d')) { flags += 'd'; }
+    return flags;
+  }
+  static #execRule(reg, action, sourceText) {
+    let m = reg.exec(sourceText);
+    if (m == null) { return false; }
+
+    action(m);
+    return true;
+  }
+  static #traverseSource(shared, sourceText) {
+    let ruleIdx = 0;
+    let lastRule = shared.#rules.length - 1;
+    while (shared.lastIndex < sourceText.length) {
+      if (shared.#rules[ruleIdx](sourceText)) { ruleIdx = 0; }
+      else { ruleIdx++; }
+
+      if (ruleIdx > lastRule) {
+        let snippet = sourceText.slice(shared.lastIndex, shared.lastIndex + 20);
+        throw 'No valid expression for [' + JSON.stringify(snippet) + '...]';
+      }
+    }
+  }
+  constructor(state, id, a, b) {
+    if (arguments.length <= 2) {
+      super(/.*/);
+      this.#rules = [];
+      Object.keys(state).forEach(k => {
+        if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
+        this[k] = new SharedStateRegEx(this, k, state[k][0]);
+        this.#rules.push(SharedStateRegEx.#execRule.bind(this, this[k], state[k][1]))
+      });
+      this.exec = function exec(str) { return SharedStateRegEx.#traverseSource(this, str); }.bind(this);
+      this.#diagMessages = id || false;
+      this.lastIndex = 0;
+      return this;
+    }
+
+    super(a, SharedStateRegEx.#patchFlags(a, b));
+    this.#state = state;
+    state.reset ||= this.reset.bind(this);
+    this.#id = id;
+  }
+
+  reset() { this.#state.lastIndex = 0; }
+  exec(str, diag) {
+    diag ||= this.#diagMessages;
+    let currentLast = this.#state.lastIndex;
+    this.lastIndex = currentLast;
+    let match = super.exec(str);
+    if (diag) {
+      let snippet = JSON.stringify(sourceText.substring(currentLast, currentLast + 20));
+      match && console.error(this.#id, this.toString(), "against", snippet, "yields", JSON.stringify(match || []));
+    }
+    if (match == null) { return null; }
+    if (match.indices[0][0] != currentLast) {
+      diag && console.error(this.#id, "did not start at lastIndex=" + currentLast, ", but at", this.lastIndex);
+      return null;
+    }
+
+    this.#state.lastIndex = this.lastIndex;
+    return match;
+  }
+  toString() { return super.toString(); }
+}
+
+/**
+ * Helper utility to maintain the current position of the parsed object graph.
+ */
+class ParseContext {
+  #STACK = []
+
+  get current() { return this.#STACK.at(-1); }
+  start() { this.#STACK = [new UniversalNode()]; }
+
+  enterNode(name, raw) {
+    let node = new UniversalNode(name, raw);
+    this.current.subNode(name, node);
+    this.#STACK.push(node);
+  }
+
+  nodeHeaderDone(raw) { this.current.headerDone(raw); }
+
+  // leave node
+  leaveNode(raw) {
+    this.current.addRaw(raw, true);
+    this.#STACK.pop();
+  }
+
+  addContent(text, raw) { this.current.content(text, raw); }
+  addAttr(name, value, raw) { this.current.attr(name, value, raw); }
+}
+
+/**
+ * To be used in conjunction with [class RegexDocParser](#class_regexdocparser).
+ * 
+ * This class represents one node of any type in the parsed tree.  
+ * Depending on how it has been populated during parsing, its `valueOf` will return different objects,
+ * simple scalar values, dictionaries or arrays.  
+ * The `valueOf()` function will also recurse into children and subNodes to ensure proper mapping of the entire graph. 
+ */
+class UniversalNode {
+  #tagName;
+  #rawValues = []
+  #rawContentIndices = []
+  #subNodes = {}
+  #text = []
+  constructor(tag, raw) {
+    this.#tagName = tag;
+    this.#rawValues.push(raw);
+  }
+  attr(name, value, raw) {
+    this.#rawValues.push(raw);
+    this[`@${name}`] = value;
+  }
+  content(text, raw = text) {
+    if (this.#rawContentIndices.length == 0) { this.#rawContentIndices.push(this.#rawValues.length) }
+    this.#rawValues.push(raw);
+    this.#text.push(text);
+  }
+  subNode(tag, node) {
+    this.#rawValues.push(node);
+    let target = (this.#subNodes[tag] ||= []);
+    target.push(node);
+  }
+  tagName() { return this.#tagName; }
+  addRaw(str, isContentEnd = false) {
+    if (isContentEnd) { this.#rawContentIndices.push(this.#rawValues.length); }
+    this.#rawValues.push(str);
+  }
+  hasAttribs() { return Object.keys(this).length > 0; }
+  hasText() { return this.#text.length > 0; }
+  isMixed() { return this.#text.length > 0 && Object.keys(this.#subNodes).length > 0 }
+  headerDone(raw) {
+    this.#rawValues.push(raw);
+    this.#rawContentIndices.push(this.#rawValues.length);
+  }
+  getText() {
+    if (this.isMixed()) { return this.#rawValues.slice(...this.#rawContentIndices).join('').trim(); }
+    else if (this.#text.length == 1) { return this.#text[0]; }
+    else { return this.#text.join('').trim(); }
+  }
+
+  valueOf() {
+    let sanitizedObject = {};
+    if (this.hasText()) {
+      if (!this.hasAttribs()) { return this.getText(); }
+      else { sanitizedObject['#text'] = this.getText() };
+    }
+    Object.keys(this.#subNodes).forEach(k => {
+      if (this.#subNodes[k].length == 1) { sanitizedObject[k] = this.#subNodes[k].pop().valueOf(); }
+      else { sanitizedObject[k] = this.#subNodes[k].map(e => e.valueOf()); }
+    });
+    let result = Object.assign({}, this, sanitizedObject);
+    if (Object.keys(result).length > 0) { return result; }
+    return null;
+  }
+
+  toString() { return this.#rawValues.join(''); }
+}
+
+/** @endsection */
+
+/**
  * @section INTERNAL SUPPORT CLASSES AND FUNCTIONS
  * @description
  * Most of the classes and functions following this block are for parsing yml files

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -128,8 +128,8 @@ function confToDict(confFile) {
 }
 
 const XML = {
-  ENCODED_CHARS_REGEX: /&lt;|&gt;|&amp;|&apos;|&quot;/,
-  removeComments: function removeComments(lines) {
+  ENCODED_CHARS_REGEX: /&lt;|&gt;|&amp;|&apos;|&quot;/g,
+  removeComments(lines) {
     if (Array.isArray(lines)) { lines = lines.join('\n') }
 
     while (lines.includes('<!--')) {
@@ -140,7 +140,11 @@ const XML = {
     return lines.split('\n');
   },
 
-  decodeValue: function(value) {
+  condenseWhitespace(value) {
+    return value.replace(/\s*$\s*/gm, ' ').trim();
+  },
+
+  decodeValue(value) {
     return value.replace(XML.ENCODED_CHARS_REGEX, match => {
       switch (match) {
         case '&lt;': return '<'
@@ -150,7 +154,11 @@ const XML = {
         case '&quot;': return '"'
       }
     });
-  }
+  },
+
+  decodeAttribute(value) {
+    return XML.decodeValue(XML.condenseWhitespace(value));
+  },
 }
 
 const CFG_PROP_LINE = /<(\w+) name="(.*)" value="(.*)"\s*\/>/
@@ -273,7 +281,6 @@ function analyseProperty(propLine) {
  * @description
  * Most of the classes and functions following this block are for parsing yml files
  * as this is the most complex format.
- * @endsection 
  */
 function readTextPropertyFile(confFile, dataLinesCallback, contentProvider = CONTENT_PROVIDER.DIRECT, ...providerArgs) {
   if (Array.isArray(confFile)) { return dataLinesCallback(confFile); }
@@ -598,6 +605,8 @@ function parseYamlLine(state = {}, line = "") {
     subDict[key] = value;
   }
 }
+
+/** @endsection */
 
 let FORMATS = Object.keys(PARSE_FUNCTIONS);
 

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -537,6 +537,7 @@ class UniversalNode {
   #subNodes = {}
   #content = []
   #contentMode = 'DYNAMIC';
+  #emptyValue = null;
 
   static realValue(obj) { return (obj instanceof UniversalNode) ? obj.valueOf() : obj; }
 
@@ -551,6 +552,9 @@ class UniversalNode {
    */
   setContentMode(cm) { this.#contentMode = cm; }
   getContentMode() { return this.#contentMode; }
+
+  /** What to return when there are no subnodes or child elements. Default is null. */
+  setEmptyValue(val) { this.#emptyValue = val; }
 
   // some small getter utils
   hasContent() { return this.#content.length > 0; }
@@ -608,7 +612,7 @@ class UniversalNode {
     });
     let result = Object.assign({}, sanitizedObject);
     if (Object.keys(result).length > 0) { return result; }
-    return null;
+    return this.#emptyValue;
   }
 
 }
@@ -838,9 +842,11 @@ class YAML extends ParseContext {
   enterFlow(flowNodeMarker) {
     this.pushNextNode('#FLOW:ROOT', false);
     this.current[YAML.MODE] = 'FLOW';
-    if (flowNodeMarker[0].trim() == "[") { this.current.setContentMode("ARRAY"); }
-    if (this.current.getContentMode() == "ARRAY") {
-      this.pushNextNode('#ARR-ENTRY', false);
+    if (flowNodeMarker[0].trim() == "[") {
+      this.current.setContentMode("ARRAY");
+      this.current.setEmptyValue([]);
+    } else {
+      this.current.setEmptyValue({});
     }
   }
 

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -313,14 +313,14 @@ class YAML extends ParseContext {
   static PARSE_MODES = ['BLOCK', 'FLOW']
   // something like a 'sub-category' of parse modes
   static PARSE_PHASES = ['ENTRY', 'TOKEN', 'TOKEN:ML']
-  static SCALAR_STYLE_OPS = { '|': "LITERAL", '>': "FOLD" }
+  static BLOCK_H_STYLES = { '|': "LITERAL", '>': "FOLD" }
+  static CHOMP_MODES = { '+': 'KEEP', '-': 'STRIP', '': 'CLIP'}
 
   static CNEST = Symbol.for('CNEST');
   static NESTING = Symbol.for('NESTING');
   static MODE = Symbol.for('MODE');
-  static SCALAR_STYLE = Symbol.for("SCALAR");
   static PHASE = Symbol.for('PHASE');
-  static LAST_TOKEN = Symbol.for('LASTTOKEN');
+  static TOKEN = Symbol.for('TOKEN');
 
   cleanNode() { Object.getOwnPropertySymbols(this.current).forEach(k => delete this.current[k]); }
   pushNextNode(tagName, isSubNode) {
@@ -334,27 +334,23 @@ class YAML extends ParseContext {
   inheritStateProperties() {
     this.current[YAML.MODE] = this.previous[YAML.MODE] || 'BLOCK';
     this.current[YAML.NESTING] = this.previous[YAML.CNEST];
-    this.current[YAML.SCALAR_STYLE] = this.previous[YAML.SCALAR_STYLE] || "FOLD";
     console.error(
       `\t--> INHERIT ${this.current.tagName()}:`, this.current[YAML.NESTING], '->', this.current[YAML.MODE],
       `from:`, this.previous.tagName(), this.previous[YAML.NESTING], this.previous[YAML.CNEST]
     );
   }
 
-  hasToken() { return Array.isArray(this.state(YAML.LAST_TOKEN)); }
-  handleToken(match) {
+  hasToken() { return typeof this.state(YAML.TOKEN) != "undefined"; }
+  handleToken(match, rule) {
     // when coming from parser directly, the first group will be token content
     // otherwise it could be called from another method with a pre-processed string
     match = Array.isArray(match) ? match[1] : match;
-    (this.current[YAML.LAST_TOKEN] ||= []).push(match);
-    let content = this.state(YAML.LAST_TOKEN).join("");
-    let hasContent = content.trim().length > 0;
+    let token = (this.current[YAML.TOKEN] ||= new YamlToken(this.current));
+    if(token.isEmpty() && ['DQ', 'SQ'].includes(rule.getId())) { token.quoteMode = rule.getId(); }
+    token.add(match);
     switch (this.state(YAML.PHASE)) {
       case "ENTRY":
-        if (hasContent) {
-          this.state(YAML.PHASE, "TOKEN");
-          this.stateOnce(YAML.SCALAR_STYLE, "FOLD");
-        }
+        if (!token.isEmpty()) { this.state(YAML.PHASE, "TOKEN"); }
         break;
       case "TOKEN":
         this.state(YAML.PHASE, "TOKEN:ML");
@@ -364,49 +360,12 @@ class YAML extends ParseContext {
   consumeToken() {
     if (!this.hasToken()) { return; }
 
-    let result = this.condenseToken();
-    delete this.current[YAML.LAST_TOKEN];
+    let result = this.state(YAML.TOKEN).get();
+    delete this.current[YAML.TOKEN];
     delete this.current[YAML.PHASE];
     return result;
   }
 
-  /** For keys and values: handles trimming, folding, chomping etc. */
-  condenseToken() {
-    console.error("\t--> CONDENSE:", this.current[YAML.LAST_TOKEN])
-    let result = this.current[YAML.LAST_TOKEN].join('');
-    if (result.trim().length == 0) { return; }
-
-    let repeater = '+';
-    // determine if (and how many) indentation/nesting spaces must be removed
-    // FIXME: cant use PHASE for this - conflicts with TOKEN:ML.
-    // TODO: introduce some 'config' subobject for SCALAR_STYLE instead of just using string constants
-    switch (this.state(YAML.PHASE)) {
-      case 'SCALAR:FL': // flow style
-        break;
-
-      case 'SCALAR:BL': // block style
-        let nesting = this.state(YAML.NESTING) || 0;
-        nesting += 0
-        break;
-    }
-    result = result.replace(r`/(?<=\n)[ \t]${repeater}(?=\S)/g`, '');
-
-    //TODO: adjust leading spaces based on nesting
-    if (this.state(YAML.SCALAR_STYLE) == "FOLD") {
-      result = result
-        .replace(/(?<=\n)[ \t]+(?=\S)/g, '')
-        .replace(/(?<=\S)[ \t]+(?=\n)/g, '')
-        .replace(/(?<=\S)\n(?=\S)/g, ' ')
-        .replace(/(?<=\S)\n(\n+)/g, '$1')
-        .trim();
-    } else {
-      let nesting = this.state(YAML.CNEST) || 0;
-      result = result
-        //remove number of characters to matching the current nesting.
-        .replace(r`/(?<=\n|^)[ \t]{${nesting}}/g`, '');
-    }
-    return unquote(result.trim());
-  }
   tokenToContent() {
     let token = this.consumeToken();
     if (typeof token == "undefined") { return }
@@ -446,8 +405,11 @@ class YAML extends ParseContext {
         break;
       case '|':
       case '>':
-        this.state(YAML.SCALAR_STYLE, YAML.SCALAR_STYLE_OPS[op.charAt(0)]);
-      //this.state(YAML.PHASE, "SCALAR:BL");
+        let tokenStyle = YAML.BLOCK_H_STYLES[op.charAt(0)];
+        let token = new YamlToken(this.current, tokenStyle);
+        this.state(YAML.TOKEN, token);
+        token.chomping = YAML.CHOMP_MODES[op.replace(/[^+-]/g, '')];
+        token.nesting = op.replace(/[^\d]/g, '');
     }
   }
 
@@ -681,7 +643,9 @@ class RegexDocParser extends RegExp {
     this.#id = id;
   }
 
+  getId() { return this.#id; }
   reset() { this.#state.lastIndex = 0; }
+  
   exec(sourceText, diag) {
     let currentLast = this.#state.lastIndex;
     this.lastIndex = currentLast;
@@ -880,6 +844,7 @@ class YamlToken {
   #style = 'FLOW'; //FLOW, (Block-)FOLD or (Block-)LITERAL
   #quoting = 'NQ'; // DQ, SQ, NQ; for FLOW only
   #chompMode = 'CLIP'; // STRIP, CLIP, KEEP
+  #indent;
 
   #token;
   #trailing;
@@ -892,10 +857,15 @@ class YamlToken {
 
   set chomping(style){ this.#chompMode = style; }
   set quoteMode(mode = "NQ") { this.#quoting = mode; }
+  set indentation(raw) {
+    let n = parseInt(raw);
+    if(Number.isNaN(n) || n < 1) { delete this.#indent; }
+    else this.#indent = n;
+  }
 
   get shiftLevel() {
     if (this.#style == "FLOW") { return '+' }
-    if (typeof this.indentation == "number") { return this.parent[YAML.NESTING] + this.indentation; }
+    if (typeof this.#indent == "number") { return this.parent[YAML.NESTING] + this.#indent; }
 
     // YAML 1.2.2 - 8.1.1.1 Block Indentation Indicator
     let m = null;

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -251,11 +251,8 @@ function xmlNew(xmlFile) {
 }
 
 function yamlToDict(yamlFile) {
-  return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
-}
-
-function yamlToDict_IMPL(yamlFile) {
   return readTextPropertyFile(yamlFile, YAML.parse, CONTENT_PROVIDER.DIRECT, false);
+  //return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
 }
 
 const FOLDER_SPEC = /^\w+(\.folder\[(".*?")\/?\]).*=.*/;
@@ -386,6 +383,10 @@ class RegexDocParser extends RegExp {
   getId() { return this.#id; }
   reset() { this.#state.lastIndex = 0; }
 
+  /** 
+   * This is where the main logic of `RegexDocParser` starts.
+   * Behaves differently for the "root" parser instance compared to its expression-bound sub-instances. 
+   */
   exec(sourceText) {
     let currentLast = this.#state.lastIndex || 0;
     this.lastIndex = currentLast;
@@ -410,6 +411,17 @@ class RegexDocParser extends RegExp {
     if (this.#state) { return this; }
     return this.currentRule || this;
   }
+  /** 
+   * Logging of parser states is very expensive because it includes several string operations.  
+   * This is method is used internally by all `log...` methods in `RegexDocParser` to disabled logging conditionally.  
+   * It also enforces a uniform log prefix format.
+   * 
+   * Internally relies on [Logger.logWhen](../logger.js.md#class_logger_logwhen)
+   * 
+   * @arg {Level} level minimum log level that has to be active for the log module named after the parser id.
+   * @arg {string} suffix will be attached to the default prefix if truthy
+   * @arg {any} data to log. Can also be a function, which will only be called when the given `level` is log-enabled. 
+   */
   #conditionalLog(level, suffix, ...data) {
     let id = this.#state ? this.#id : null;
     if (this.#log.excludeRules.includes(id || '%SELF')) { return; }
@@ -428,9 +440,9 @@ class RegexDocParser extends RegExp {
   /** Logs on INFO level and bound to `%SELF` topic instead of the rule id. */
   log(...data) { (this.#state || this).#conditionalLog('INFO', '', ...data); }
   /** Logs on DEBUG level */
-  logRule(...data) { this.activeRule.#conditionalLog('INFO', '', ...data); }
+  logRule(...data) { this.activeRule.#conditionalLog('DEBUG', '', ...data); }
   /** Logs on TRACE level  */
-  logDetails(...data) { this.activeRule.#conditionalLog('INFO', '   -->', ...data); }
+  logDetails(...data) { this.activeRule.#conditionalLog('TRACE', '   -->', ...data); }
 
   /** Return a short part from the beginning of the given string, with breaks and tabs encoded. */
   snippet(sourceText, startIndex) {
@@ -442,8 +454,9 @@ class RegexDocParser extends RegExp {
 }
 
 /**
- * Utilities to handle the complex parser state when parsing yaml.  
- * Methods of this object will be called with `this` set to the instance of the current `ParseContext`.
+ * Utilities to manage the state of GenericRegexParser.  
+ * Methods of this object will be called with `this` set to the instance of the current `ParseContext`
+ * after `bindFunctions` was used.
  */
 class ParseContext {
   #STACK = []
@@ -687,6 +700,27 @@ class PropValue {
 /**
  *  @section YAML-specific code
  */
+
+/**
+ * `YAML` is a specialised sub-class of `ParseContext`.  
+ * It encapsulates state handling of yaml parsing processes, as well as the configuration of an instance of `RegexDocParser`.  
+ * This parser implementation is generally very lenient in terms of errors. Most statements from the spec in the form
+ * `it is an error...` have just been ignored when this was implemented. The yaml-spec and format is confusing enough,
+ * being strict about every space doesn't help stability at all.  
+ * 
+ * Where applicable, this implementation attempts to produce outputs equal to `pyyaml` because the original tooling
+ * of batocera is implemented in python.
+ * 
+ * **Note:**  
+ * This is NOT a fully feature-complete yaml parser. It should be enough to cover almost any basic feature found in
+ * batocera's config files, but the following advanced features are not supported:
+ * - tags: will be trated as content strings
+ * - anchors: will be treated as content strings
+ * - parser directives: ignored like comments. '%' is effectively identical to '#'.
+ * - several cases of yaml-specific value "interpretations" of none-quoted values:  
+ *   Unquoted values are internally parsed with `JSON.parse`, so anything not supported by this will just be a string.
+ * - Contrary to spec, this parser supports multiline dictionary keys.
+ */
 class YAML extends ParseContext {
   static BLOCK_H_STYLES = { '|': "LITERAL", '>': "FOLD" }
   static CHOMP_MODES = { '+': 'KEEP', '-': 'STRIP', '': 'CLIP' }
@@ -902,9 +936,9 @@ class YAML extends ParseContext {
 }
 
 /** 
- * Encapsulates transformation of raw (multiline) tokens into the corresponding final output value.
- * - It handles all folding, trimming and chomping for styles of strings.
- * - One-word unquoted tokens will be evaluated as JSON primitives with string as fallback on failure.
+ * This class encapsulates transformation of raw (multiline) yaml tokens into the corresponding final output value.
+ * - It handles all folding, trimming and chomping for all styles of strings.
+ * - One-word unquoted tokens will be evaluated as JSON primitives with simple stringification as fallback on failure.
  *
  * **API:**  
  * 1. token style is set in constructor, must be one of (`FLOW`, (Block-)`FOLD` or (Block-)`LITERAL`)
@@ -1113,7 +1147,7 @@ module.exports = {
   parseDict, analyseProperty,
   SOURCE_FILE,
   // expose the parse functions themselves for places where the type is know, but not matching the extension
-  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict, yamlToDict_IMPL,
+  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict,
   //for information/API puposes
   FORMATS,
   XML,

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -214,7 +214,13 @@ function xmlToDict(xmlFile) {
 function xmlNew(xmlFile) {
   let result = readTextPropertyFile(xmlFile, sourceText => {
     let diag = false;
+
     let context = new ParseContext();
+    context.addAttributeNode = function(m) {
+      this.enterNode(`@${m[1]}`, m[1] + '=');
+      this.addContent(handleValue(XML.decodeAttribute(m[2].slice(1, -1))), m[2])
+      this.leaveNode();
+    }.bind(context);
 
     let R = new RegexDocParser({
       // none-node whitespace
@@ -222,10 +228,7 @@ function xmlNew(xmlFile) {
       // start of node
       SON: [/<(?!\/)([\p{L}\._\d-]+?)([\s>]|(?=\/))/su, m => context.enterNode(m[1], m[0])],
       //attribute
-      NATTR: [
-        /(\w+)=("[^"]*"|'[^']*')/s,
-        m => context.addAttr(m[1], handleValue(XML.decodeAttribute(m[2].slice(1, -1))), m[0])
-      ],
+      NATTR: [/(\w+)=("[^"]*"|'[^']*')/s, context.addAttributeNode],
       // end of node opening tag
       EOH: [/\s*\>/ms, m => context.nodeHeaderDone(m[0])],
       // node value/content
@@ -238,7 +241,6 @@ function xmlNew(xmlFile) {
     sourceText = sourceText.replace(/\<!--.*?--\>/gs, '');
 
     context.start();
-
     R.exec(sourceText);
 
     return context.current.valueOf();
@@ -252,39 +254,317 @@ function yamlToDict(yamlFile) {
   return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
 }
 
-// TODO/FIXME: re-activate and enhance self-written parser code because it is more efficient
-// than spawning yq/xq in a subprocess.
-// Also requires an XML parser
-function yamlToDict_old(yamlFile) {
-  return readTextPropertyFile(yamlFile, (lines) => {
-    let result = new FlexibleContainer('#root', -1);
-    let state = { stack: new ParseStack(result), depth: result[Symbol.for("depth")], line: 0 }
-    for (let line of lines) {
-      try {
-        state.line++;
-        let retryCount = 0
-        do {
-          if (retryCount > 50) {
-            log.debug("Stop retrying line", `[${state.line}] '${line}'`, 'after 50 retries to prevent endless looping');
-            break;
-          }
-          retryCount++;
-          state.lineDone = true;
-          parseYamlLine(state, line);
-        } while (!state.lineDone)
-      } catch (e) {
-        log.error("LINE", line, "\nSTATE", state, e)
-        process.exit(1)
+/**
+ * Utilities to handle the complex parser state when parsing yaml.
+ * Methods of this object will be called with `this` set to the instance of the current `ParseContext`.
+ */
+class ParseContext {
+  #STACK = []
+
+  get root() { return this.#STACK[0]; }
+  get current() { return this.#STACK.at(-1); }
+  get previous() { return this.#STACK.at(-2); }
+
+  /** 
+   * `this` is normally lost when methods are used as callbacks.
+   * This method overrides that by assigning a bound variant of the class method as instance property.
+   * Passing the instance property as callback means passing a pre-bound function.
+   */
+  bindFunctions() {
+    Object.values(Object.getOwnPropertyDescriptors(Object.getPrototypeOf(this))).forEach(v => {
+      v = v.value;
+      if (typeof v == "function") { this[v.name] = v.bind(this) }
+    });
+  }
+
+  start(parser) {
+    this.parser = parser;
+    this.#STACK = [new UniversalNode('#root')];
+  }
+
+  enterNode(name, raw = name) {
+    let node = new UniversalNode(name, raw);
+    this.current.subNode(name, node);
+    this.#STACK.push(node);
+    console.error('\t--> ENTER', this.current.tagName())
+  }
+
+  addChildNode(tag) {
+    let node = new UniversalNode(tag);
+    this.current.content(node)
+    this.#STACK.push(node);
+    console.error('\t--> PUSH CHILD:', tag)
+  }
+
+  nodeHeaderDone(raw) { this.current.headerDone(raw); }
+
+  // leave node
+  leaveNode(raw) {
+    console.error('\t--> LEAVE', this.current.tagName(), this.current)
+    this.current.addRaw(raw, true);
+    this.#STACK.pop();
+  }
+
+  addContent(text, raw) { this.current.content(text, raw); }
+}
+
+class YAML extends ParseContext {
+  // PARSE_MODES is not actively used (referenced in the code)
+  static PARSE_MODES = ['BLOCK', 'FLOW']
+  // something like a 'sub-category' of parse modes
+  static PARSE_PHASES = ['ENTRY', 'TOKEN', 'TOKEN:ML']
+  static SCALAR_STYLE_OPS = { '|': "LITERAL", '>': "FOLD" }
+
+  static CNEST = Symbol.for('CNEST');
+  static NESTING = Symbol.for('NESTING');
+  static MODE = Symbol.for('MODE');
+  static SCALAR_STYLE = Symbol.for("SCALAR");
+  static PHASE = Symbol.for('PHASE');
+  static LAST_TOKEN = Symbol.for('LASTTOKEN');
+
+  cleanNode() { Object.getOwnPropertySymbols(this.current).forEach(k => delete this.current[k]); }
+  pushNextNode(tagName, isSubNode) {
+    if (typeof isSubNode == "undefined") { isSubNode = tagName ? String(tagName).length > 0 : false; }
+    let factory = isSubNode ? this.enterNode : this.addChildNode;
+    factory.call(this, tagName);
+    this.inheritStateProperties();
+    this.current[YAML.PHASE] = "ENTRY";
+    delete this.previous[YAML.PHASE];
+  }
+  inheritStateProperties() {
+    this.current[YAML.MODE] = this.previous[YAML.MODE] || 'BLOCK';
+    this.current[YAML.NESTING] = this.previous[YAML.CNEST];
+    this.current[YAML.SCALAR_STYLE] = this.previous[YAML.SCALAR_STYLE] || "FOLD";
+    console.error(
+      `\t--> INHERIT ${this.current.tagName()}:`, this.current[YAML.NESTING], '->', this.current[YAML.MODE],
+      `from:`, this.previous.tagName(), this.previous[YAML.NESTING], this.previous[YAML.CNEST]
+    );
+  }
+
+  hasToken() { return Array.isArray(this.state(YAML.LAST_TOKEN)); }
+  handleToken(match) {
+    // when coming from parser directly, the first group will be token content
+    // otherwise it could be called from another method with a pre-processed string
+    match = Array.isArray(match) ? match[1] : match;
+    (this.current[YAML.LAST_TOKEN] ||= []).push(match);
+    let content = this.state(YAML.LAST_TOKEN).join("");
+    let hasContent = content.trim().length > 0;
+    switch (this.state(YAML.PHASE)) {
+      case "ENTRY":
+        if (hasContent) {
+          this.state(YAML.PHASE, "TOKEN");
+          this.stateOnce(YAML.SCALAR_STYLE, "FOLD");
+        }
+        break;
+      case "TOKEN":
+        this.state(YAML.PHASE, "TOKEN:ML");
+        break;
+    }
+  }
+  consumeToken() {
+    if (!this.hasToken()) { return; }
+
+    let result = this.condenseToken();
+    delete this.current[YAML.LAST_TOKEN];
+    delete this.current[YAML.PHASE];
+    return result;
+  }
+
+  /** For keys and values: handles trimming, folding, chomping etc. */
+  condenseToken() {
+    console.error("\t--> CONDENSE:", this.current[YAML.LAST_TOKEN])
+    let result = this.current[YAML.LAST_TOKEN].join('');
+    if (result.trim().length == 0) { return; }
+
+    let repeater = '+';
+    // determine if (and how many) indentation/nesting spaces must be removed
+    // FIXME: cant use PHASE for this - conflicts with TOKEN:ML.
+    // TODO: introduce some 'config' subobject for SCALAR_STYLE instead of just using string constants
+    switch (this.state(YAML.PHASE)) {
+      case 'SCALAR:FL': // flow style
+        break;
+
+      case 'SCALAR:BL': // block style
+        let nesting = this.state(YAML.NESTING) || 0;
+        nesting += 0
+        break;
+    }
+    result = result.replace(r`/(?<=\n)[ \t]${repeater}(?=\S)/g`, '');
+
+    //TODO: adjust leading spaces based on nesting
+    if (this.state(YAML.SCALAR_STYLE) == "FOLD") {
+      result = result
+        .replace(/(?<=\n)[ \t]+(?=\S)/g, '')
+        .replace(/(?<=\S)[ \t]+(?=\n)/g, '')
+        .replace(/(?<=\S)\n(?=\S)/g, ' ')
+        .replace(/(?<=\S)\n(\n+)/g, '$1')
+        .trim();
+    } else {
+      let nesting = this.state(YAML.CNEST) || 0;
+      result = result
+        //remove number of characters to matching the current nesting.
+        .replace(r`/(?<=\n|^)[ \t]{${nesting}}/g`, '');
+    }
+    return unquote(result.trim());
+  }
+  tokenToContent() {
+    let token = this.consumeToken();
+    if (typeof token == "undefined") { return }
+
+    console.error('\t--> ASSIGN TOKEN', token);
+    this.addContent(handleValue(token));
+  }
+
+  enterFlow(flowNodeMarker) {
+    this.pushNextNode('#FLOW:ROOT', false);
+    this.current[YAML.MODE] = 'FLOW';
+    if (flowNodeMarker[0].trim() == "[") { this.current.setContentMode("ARRAY"); }
+    if (this.current.getContentMode() == "ARRAY") {
+      this.pushNextNode('#ARR-ENTRY', false);
+    }
+  }
+
+  closeFlow(match) {
+    let term = match[0].replace(/\s+/gm, '');
+    if (term == ',') {
+      this.current.getContentMode() == "ARRAY" ? this.tokenToContent() : this.finishCurrentNode();
+      return;
+    }
+
+    this.finishCurrentNode();
+    if (!this.previous) { return; }
+    console.error('\t    MODES (p,c)', this.previous[YAML.MODE], this.current[YAML.MODE])
+    if (this.current.tagName() == "#FLOW:ROOT") { this.finishCurrentNode(); }
+  }
+
+  handleOperator(op, reg, source) {
+    op = op[0];
+    switch (op.charAt(0)) {
+      case ':':
+        let token = this.consumeToken();
+        this.pushNextNode(token);
+        break;
+      case '|':
+      case '>':
+        this.state(YAML.SCALAR_STYLE, YAML.SCALAR_STYLE_OPS[op.charAt(0)]);
+      //this.state(YAML.PHASE, "SCALAR:BL");
+    }
+  }
+
+  markArray(depth, addChild = true) {
+    depth = Number(depth) || 2;
+    console.error("\t--> MARK ARRAY:", this.current.tagName(), 'N:', this.state(YAML.NESTING), 'CN:', this.current[YAML.CNEST]);
+    if (this.current.getContentMode() != "ARRAY") {
+      this.pushNextNode(this.current.tagName() + '[]', false);
+      this.state(YAML.NESTING, this.previous[YAML.NESTING]);
+      this.state(YAML.CNEST, this.previous[YAML.CNEST]);
+      this.current.setContentMode("ARRAY");
+    }
+
+    if (addChild) {
+      this.pushNextNode(this.current.tagName() + '#' + this.current.getContentLength(), false);
+      this.state(YAML.CNEST, this.state(YAML.NESTING) + depth);
+    }
+  }
+
+  finishCurrentNode() {
+    this.tokenToContent();
+    this.cleanNode();
+    this.leaveNode();
+  }
+
+  state(state, value, node) {
+    node ||= this.current;
+    if (value == undefined) { return node[state]; }
+    node[state] = value;
+    console.error(`\t--> ${Symbol.keyFor(state)} ${value} >>> ${node.tagName()}`)
+  }
+
+  /** Only SET value if state is not set already */
+  stateOnce(state, value, node) {
+    node ||= this.current;
+    if (typeof value == "undefined") { throw "stateOnce() must receive a value argument" }
+    if (typeof node[state] == "undefined") { this.state(state, value, node); }
+  }
+
+  closeNodes(depthMatch) {
+    let regD = depthMatch[1].length;
+    let arrD = regD;
+    if (depthMatch[0].trim().endsWith('-')) {
+      arrD += 2;
+      this.parser.lastIndex -= 2;
+    }
+    while (true) {
+      if (arrD > regD && arrD > this.state(YAML.NESTING) && "ENTRY" == this.state(YAML.PHASE)) {
+        this.state(YAML.CNEST, regD);
+        this.markArray(arrD - regD, false);
       }
+      let diff = this.state(YAML.NESTING) - (this.current.getContentMode() == "ARRAY" ? arrD : regD);
+      console.error("\t--> RCL:" + this.current.tagName(), 'N:', this.current[YAML.NESTING], 'D:', diff, regD, arrD)
+
+      if (diff >= 0) { this.finishCurrentNode(depthMatch); }
+      else { break; }
     }
-    while (state.stack.length > 0) {
-      let current = state.stack.peek();
-      //last line in yml was a multi line, need to merge down and close block
-      if (current instanceof MLModeHandler) { current.endBlock(state, 'EOF') }
-      else { state.stack.pop() }
+    this.stateOnce(YAML.CNEST, arrD);
+    //save whitespace for unquoted multiline Strings
+    this.handleToken(depthMatch[0].substring(0, regD + 1));
+  }
+}
+
+function yamlToDict_IMPL(yamlFile) {
+  return readTextPropertyFile(yamlFile, sourceText => {
+
+    let yaml = new YAML();
+    yaml.bindFunctions();
+
+    function isMode(m, isIncluded = true) { return () => m.includes(yaml.current[YAML.MODE]) == isIncluded; }
+    function isPhase(p, isIncluded = true) { return () => p.includes(yaml.current[YAML.PHASE]) == isIncluded; }
+
+    let R = new RegexDocParser({
+      // NOOP: Comments - (at least) one whitespace followed by whatever up to the next \n.
+      // only allowed while not in the middle of a multiline token, treat it as regular content otherwise
+      LC: [/(?:^|\s)+#.*?(?=$)/m, false, isPhase(["TOKEN:ML"], false)],
+      // Empty lines
+      EL: [/\n[ \t]*(?=\n|$)/m, yaml.handleToken],
+      'BL:ARR': [/(-)(?=\s)/, yaml.markArray, isMode('BLOCK')],
+      // From " on anything up until the first unescaped " (unescaped: no uneven number of slashes before it)
+      // can run over multiple lines.
+      DQ: [/("(?:\\\\|\\"|\\[^"]|[^\\"])*")/m, yaml.handleToken],
+      // single quoted tokens
+      SQ: [/('(?:''|[^'])*')/m, yaml.handleToken],
+      // block scalar indicators
+      'BL:SLH': [/([|>]|[|>][+-]\d|[|>]\d[+-])(?=[ \t\n])/, yaml.handleOperator, isMode('BLOCK')],
+      // indicators which are not allowed in unquoted tokens
+      OP: [/([:?](?=[ \t\n]))/, yaml.handleOperator],
+      // indicators/operators belonging to flow mode: [], {}, ','
+      'FL:OP': [/\{|\[/, yaml.enterFlow],
+      'FL:X': [/\s*(?:,[ \t]*\}|,[ \t]*\]|[,\}\]])/, yaml.closeFlow, isMode('FLOW')],
+      // unquoted in FLOW mode has additional terminators `,`, `}` and `]`
+      'NQ:FL': [/(\S.*?)(?=[:?-]\s|[\]\},]|\s#|\n)/, yaml.handleToken, isMode('FLOW')],
+      // any unquoted one-liner, up to the first indicator or linebreak
+      // note: might have issues at end of file - requires an additional space or \n
+      NQ: [/(\S.*?)(?=[:?-]\s|\s#|\n|$)/, yaml.handleToken],
+      // the whitespace at the beginning of a line which controls when to leave a nested level
+      DPT: [/(?:^|\n)([ \t]*)(-\s)?(?=[^\-\n]|\S)/m, yaml.closeNodes, isMode('BLOCK')],
+      // In FLOW, only take the leading whitespaces as parts of the token, they are not used for closing.
+      'DPT:FL': [/(\n\s*)/, yaml.handleToken, isMode('FLOW')],
+      // NOOP: trailing whitespace from payload up to the next \n
+      TRAIL: [/[ \t]+(?=\S|\n|$)/m, () => { }]
+    }, true);
+
+    yaml.start(R);
+    yaml.current[YAML.NESTING] = -1;
+    yaml.current[YAML.MODE] = 'BLOCK';
+    try {
+      R.exec(sourceText);
+      yaml.closeNodes(["", ""]);
+      yaml.cleanNode();
+
+    } finally {
+      console.error(JSON.stringify(yaml.root.valueOf(), null, 2))
     }
-    return result.valueOf();
-  });
+    return yaml.current.valueOf();
+  }, CONTENT_PROVIDER.DIRECT, false);
 }
 
 const FOLDER_SPEC = /^\w+(\.folder\[(".*?")\/?\]).*=.*/;
@@ -315,6 +595,8 @@ function analyseProperty(propLine) {
 
 /**
  * @section Generic parser infrastructure
+ * @description
+ * The following functions and classes provide basic plumbing and utility for all type-specific parsing implementations.
  */
 
 /**
@@ -342,24 +624,32 @@ class RegexDocParser extends RegExp {
   #diagMessages;
   #state;
   #rules = false;
+  #ruleIds = false;
   static #patchFlags(reg, flags) {
     flags ||= reg.flags;
     if (!flags.includes('y')) { flags += 'y'; }
     if (!flags.includes('d')) { flags += 'd'; }
     return flags;
   }
-  static #execRule(reg, action, sourceText) {
-    let m = reg.exec(sourceText);
+  static #escapeSpaces(str) { return str.replace(/\n/g, '\\n').replace(/\t/g, '\\t'); }
+  static #execRule(reg, action, useAllowed, sourceText, diag) {
+    if (!useAllowed()) { return false; }
+
+    let m = reg.exec(sourceText, diag);
     if (m == null) { return false; }
 
-    action(m);
-    return true;
+    let result = action
+      ? action(m, reg, sourceText) || true
+      : true;
+    this.previousMatch = m;
+    return result;
   }
   static #traverseSource(shared, sourceText) {
     let ruleIdx = 0;
     let lastRule = shared.#rules.length - 1;
     while (shared.lastIndex < sourceText.length) {
-      if (shared.#rules[ruleIdx](sourceText)) { ruleIdx = 0; }
+      let ruleResult = shared.#rules[ruleIdx](sourceText, shared.#diagMessages);
+      if (ruleResult) { ruleIdx = shared.#ruleIds[ruleResult] || 0; }
       else { ruleIdx++; }
 
       if (ruleIdx > lastRule) {
@@ -372,10 +662,12 @@ class RegexDocParser extends RegExp {
     if (arguments.length <= 2) {
       super(/.*/);
       this.#rules = [];
+      this.#ruleIds = {};
       Object.keys(state).forEach(k => {
         if (this[k]) { throw `Duplicate pattern name: ${k} (or reserved word)`; }
         this[k] = new RegexDocParser(this, k, state[k][0]);
-        this.#rules.push(RegexDocParser.#execRule.bind(this, this[k], state[k][1]))
+        this.#ruleIds[k] = this.#rules.length;
+        this.#rules.push(RegexDocParser.#execRule.bind(this, this[k], state[k][1], state[k][2] || (() => true)));
       });
       this.exec = function exec(str) { return RegexDocParser.#traverseSource(this, str); }.bind(this);
       this.#diagMessages = id || false;
@@ -390,14 +682,21 @@ class RegexDocParser extends RegExp {
   }
 
   reset() { this.#state.lastIndex = 0; }
-  exec(str, diag) {
-    diag ||= this.#diagMessages;
+  exec(sourceText, diag) {
     let currentLast = this.#state.lastIndex;
     this.lastIndex = currentLast;
-    let match = super.exec(str);
+    let match = super.exec(sourceText);
+    diag = !['TRAIL'].includes(this.#id);
     if (diag) {
-      let snippet = JSON.stringify(sourceText.substring(currentLast, currentLast + 20));
-      match && console.error(this.#id, this.toString(), "against", snippet, "yields", JSON.stringify(match || []));
+      let snippet = RegexDocParser.#escapeSpaces(sourceText
+        .substring(currentLast, currentLast + 30)
+      ).substring(0, 32).padEnd(35, '.');
+      match && console.error(
+        `[${this.#id.padStart(6)}] `,
+        `${snippet}`,
+        "=>",
+        '[' + RegexDocParser.#escapeSpaces((match || []).join('|')) + ']'
+      );
     }
     if (match == null) { return null; }
     if (match.indices[0][0] != currentLast) {
@@ -412,98 +711,106 @@ class RegexDocParser extends RegExp {
 }
 
 /**
- * Helper utility to maintain the current position of the parsed object graph.
- */
-class ParseContext {
-  #STACK = []
-
-  get current() { return this.#STACK.at(-1); }
-  start() { this.#STACK = [new UniversalNode()]; }
-
-  enterNode(name, raw) {
-    let node = new UniversalNode(name, raw);
-    this.current.subNode(name, node);
-    this.#STACK.push(node);
-  }
-
-  nodeHeaderDone(raw) { this.current.headerDone(raw); }
-
-  // leave node
-  leaveNode(raw) {
-    this.current.addRaw(raw, true);
-    this.#STACK.pop();
-  }
-
-  addContent(text, raw) { this.current.content(text, raw); }
-  addAttr(name, value, raw) { this.current.attr(name, value, raw); }
-}
-
-/**
  * To be used in conjunction with [class RegexDocParser](#class_regexdocparser).
  * 
- * This class represents one node of any type in the parsed tree.  
- * Depending on how it has been populated during parsing, its `valueOf` will return different objects,
- * simple scalar values, dictionaries or arrays.  
- * The `valueOf()` function will also recurse into children and subNodes to ensure proper mapping of the entire graph. 
+ * This class represents one node of any type in the parsed tree. Its basic capabilities are inspired by the structure produced by `xmlToDict`.
+ * Depending on how it is populated during parsing, its `valueOf()` method will return different objects:
+ * Either simple scalar values, dictionaries or arrays.  
+ * This implementation will also recurse into children and subNodes to ensure proper mapping of the entire graph.
+ *
+ * `UniversalNode` internally manages 3 containers where content can be added:
+ * - `#subNodes = {}`: Populated by `attr(name, value)` and `subNode(tag, node)`.
+ *   Used for key-value tree structures. Like in `xmlToDict`, the same key can be used multiple times, `#subNodes` maintains each key's containt as array.
+ * - `#content = []`: For lists or otherwise mixed content which is not (or shall not) be added as a property of this instance.
+ * - `#rawValues = []`: This is used in all content adding methods in addition to either `#subNodes` or `#content`
+ *   to maintain an unmodified view of the literal input source. Required for some edge cases of mixed content (specific to XML).
+ *
+ * Result:  
+ * Usually, only one of either `#subNodes` or `#content` will be populated and `UniversalNode` is able to decide on its own what to return.  
+ * Refer to [valueOf()](#class_universalnode_valueof) for details.
  */
 class UniversalNode {
   #tagName;
   #rawValues = []
   #rawContentIndices = []
   #subNodes = {}
-  #text = []
+  #content = []
+  #contentMode = 'DYNAMIC';
+
+  static realValue(obj) { return (obj instanceof UniversalNode) ? obj.valueOf() : obj; }
+
   constructor(tag, raw) {
     this.#tagName = tag;
     this.#rawValues.push(raw);
   }
+
+  /** 
+   * ContentMode allows to control how the children and subnodes of this will be added when `getContent()` is used.  
+   * Must be one of DYNAMIC, ARRAY or TEXT.
+   */
+  setContentMode(cm) { this.#contentMode = cm; }
+  getContentMode() { return this.#contentMode; }
+
+  // some small getter utils
+  tagName() { return this.#tagName; }
+  hasContent() { return this.#content.length > 0; }
+  getContentLength() { return this.#content.length; }
+  isMixed() { return this.hasContent() && Object.keys(this.#subNodes).length > 0 }
+  toString() { return this.#rawValues.join(''); }
+
+  // methods to manipulate the content of the instance
+  /** 
+   * Add an 'attribute' to the node. Attributes are similar to subNodes, with 2 differences:
+   * - The name given will automatically be prefixed with `@`.
+   * - Attributes do not allow several items. Every assignment to the same attribute will overwrite the current value.
+   */
   attr(name, value, raw) {
     this.#rawValues.push(raw);
-    this[`@${name}`] = value;
+    this.#subNodes[`@${name}`] = [value];
   }
   content(text, raw = text) {
     if (this.#rawContentIndices.length == 0) { this.#rawContentIndices.push(this.#rawValues.length) }
     this.#rawValues.push(raw);
-    this.#text.push(text);
+    this.#content.push(text);
   }
   subNode(tag, node) {
     this.#rawValues.push(node);
     let target = (this.#subNodes[tag] ||= []);
     target.push(node);
   }
-  tagName() { return this.#tagName; }
   addRaw(str, isContentEnd = false) {
     if (isContentEnd) { this.#rawContentIndices.push(this.#rawValues.length); }
     this.#rawValues.push(str);
   }
-  hasAttribs() { return Object.keys(this).length > 0; }
-  hasText() { return this.#text.length > 0; }
-  isMixed() { return this.#text.length > 0 && Object.keys(this.#subNodes).length > 0 }
   headerDone(raw) {
     this.#rawValues.push(raw);
     this.#rawContentIndices.push(this.#rawValues.length);
   }
-  getText() {
+  getContent() {
+    switch (this.#contentMode) {
+      case 'ARRAY': return this.#content.map(UniversalNode.realValue);
+      case 'TEXT': return this.#content.join('').trim();
+    }
     if (this.isMixed()) { return this.#rawValues.slice(...this.#rawContentIndices).join('').trim(); }
-    else if (this.#text.length == 1) { return this.#text[0]; }
-    else { return this.#text.join('').trim(); }
+    else if (this.#content.length == 1) { return UniversalNode.realValue(this.#content[0]); }
+    else { return this.#content.join('').trim(); }
   }
 
   valueOf() {
     let sanitizedObject = {};
-    if (this.hasText()) {
-      if (!this.hasAttribs()) { return this.getText(); }
-      else { sanitizedObject['#text'] = this.getText() };
+    if (this.hasContent()) {
+      if (!this.isMixed()) { return this.getContent(); }
+      else { sanitizedObject['#text'] = this.getContent(); }
     }
     Object.keys(this.#subNodes).forEach(k => {
-      if (this.#subNodes[k].length == 1) { sanitizedObject[k] = this.#subNodes[k].pop().valueOf(); }
-      else { sanitizedObject[k] = this.#subNodes[k].map(e => e.valueOf()); }
+      if (this.#subNodes[k].length == 1) { sanitizedObject[k] = UniversalNode.realValue(this.#subNodes[k].at(0)); }
+      else { sanitizedObject[k] = this.#subNodes[k].map(UniversalNode.realValue); }
     });
-    let result = Object.assign({}, this, sanitizedObject);
+    let result = Object.assign({}, sanitizedObject);
     if (Object.keys(result).length > 0) { return result; }
     return null;
   }
 
-  toString() { return this.#rawValues.join(''); }
 }
 
 /** @endsection */
@@ -523,223 +830,102 @@ function readTextPropertyFile(confFile, dataLinesCallback, contentProvider = CON
     log.info('READ %s', confFile);
   }
   else { log.info('Data to parse is string...') }
+  let failure;
   try {
     let content = contentProvider(confFile, ...providerArgs);
     return dataLinesCallback(content);
   }
-  catch (e) { log.error(e); }
+  catch (e) { log.error(e); failure = e; }
   finally { CURRENT_FILE = null }
+  if (failure) { throw failure; }
+}
+
+/** To be used as a tag function for building regexes dynamically. Backslashes can be used as in literal RegExp with `/.../`, no escaping needed. */
+function r(constants, ...paras) {
+  let raw = constants.raw.map(e => e + (paras.shift() || '')).join('');
+  if (raw.startsWith('/')) {
+    let regTerm = raw.lastIndexOf('/');
+    let flags = raw.substring(regTerm + 1);
+    return new RegExp(raw.substring(1, regTerm), flags)
+  }
+  return new RegExp(raw);
 }
 
 /** YAML FILES */
-class ParseStack extends Array {
-  constructor() { super(...arguments); }
-  peek() { return this.at(-1); }
-}
-
-class FlexibleContainer extends Array {
-  static #unwrapFlex(object) {
-    return object instanceof FlexibleContainer
-      ? object.valueOf() : object;
-  }
-  static #isNonEmpty(object) {
-    if (!Array.isArray(object) && object instanceof Object) { object = Object.keys(object); }
-    if (Array.isArray(object)) { return object.length > 0; }
-
-    return ("" + object).length > 0;
-  }
-
-  constructor(key, depth) {
-    super()
-    this[Symbol.for("ISOBJ")] = true;
-    this[Symbol.for("KEY")] = key;
-    this[Symbol.for("depth")] = depth;
-  }
-  [Symbol.for("MK_ARR")]() { this[Symbol.for("ISOBJ")] = false; }
-  valueOf() {
-    if (this[Symbol.for("ISOBJ")]) {
-      let obj = (this[Symbol.for("obj")] ||= {});
-      Object.keys(obj).forEach(k => {
-        if (typeof this[k] == "undefined") { delete obj[k]; }
-      });
-      Object.keys(this).forEach(k => {
-        let tmp = FlexibleContainer.#unwrapFlex(this[k]);
-        if (FlexibleContainer.#isNonEmpty(tmp)) { obj[k] = tmp; }
-      });
-      return obj;
-    } else {
-      let arr = (this[Symbol.for("arr")] ||= []);
-      arr.length = 0;
-      return arr.push(...Object.values(this).map(FlexibleContainer.#unwrapFlex)), arr;
-    }
-  }
-  toJSON() { return this.valueOf() }
-}
-
-const WHITESPACE = /^(\s*).*$/
-
-class MLModeHandler {
-  constructor(type, state, skipTest = (line = "", trimmed = line.trim()) => trimmed.length == 0 || trimmed.startsWith('#')) {
-    this.type = type;
-    this.canSkip = skipTest;
-    this.depth = 0;
-  }
-  continue() { throw 'must be implemented with (state, line)' }
-  isEnd() { throw 'must be implemented with (state, line)' }
-  /**
-   * return false if the current line is NOT processed by handler,
-   * but only serves as terminator
-   */
-  endBlock() { throw 'must be implemented with (state, line)' }
-
-  recalcDepth(state, line) {
-    let newDepth = WHITESPACE.exec(line)[1].length || 0;
-    if (newDepth > this.depth) { state.stepWidth = newDepth - this.depth }
-    return state.depth = newDepth, newDepth;
-  }
-  lineDepth(line) { return WHITESPACE.exec(line)[1].length || 0; }
-}
-
-class StringMultiline extends MLModeHandler {
-  constructor(state, line, key) {
-    super("STRING", state, () => false);
-    let lines = this.lines = [];
-    this.depth = this.lineDepth(line);
-    Object.defineProperty(state.stack.peek(), key, {
-      enumerable: true, get() { return lines.join('\n').trim(); }
-    });
-    state.stack.push(this);
-  }
-
-  continue(state, line) {
-    if (!this.stringDepth) { this.stringDepth = this.recalcDepth(state, line); }
-    this.lines.push(line.substring(this.stringDepth).trimEnd());
-  }
-  isEnd(state, line) {
-    let depth = WHITESPACE.exec(line)[1].length || 0;
-    return line.length > 0 && depth <= this.depth;
-  }
-  endBlock(state) { return state.stack.pop(), false; }
-}
-
-class ListMultiline extends MLModeHandler {
-  static LIST_LINE = /^(\s*\-\s*)(.*?)\s*?(#.*)?$/;
-  constructor(state, line, key) {
-    super("LIST", state);
-    let lines = this.lines = state.stack.peek();
-    lines[Symbol.for("MK_ARR")]();
-    this.depth = lines[Symbol.for("depth")];
-    state.stack.push(this);
-    state.lineDone = false
-  }
-
-  continue(state, line) {
-    let value = ListMultiline.LIST_LINE.exec(line)[2];
-    try {
-      state.stack.push(this.lines);
-      parseYamlLine(state, `${''.padStart(this.depth + 2, ' ')}${this.lines.length}: ${value}`);
-    } finally {
-      if (state.stack.peek() == this.lines) { state.stack.pop(); }
-    }
-  }
-  isEnd(state, line) { return !ListMultiline.LIST_LINE.test(line); }
-  endBlock(state) { return state.stack.pop(), false; }
-}
-
-class ArrayMultiline extends MLModeHandler {
-  static VALUE_TRIMMER = /^\s*\[?\s*(.*?)\s*\]?\s*$/;
-  constructor(state, line, key, value) {
-    super("ARRAY", state);
-    this.depth = this.recalcDepth(state, line);
-    let lines = this.concatted = [];
-    this.continue(state, value);
-    this.oneLiner = this.isEnd(state, value);
-    Object.defineProperty(state.stack.peek(), key, {
-      enumerable: true, get() { return lines.join('\n').split(/,\s+/).map(handleValue); }
-    });
-    state.stack.push(this);
-  }
-  continue(state, line) { this.concatted.push(ArrayMultiline.VALUE_TRIMMER.exec(line)[1]); }
-  isEnd(state, line) { return this.oneLiner || /.*\]\s*$/m.test(line); }
-  endBlock(state, line) {
-    state.stack.pop();
-    if (this.oneLiner) { return false; }
-    else { return this.continue(state, line), true; }
-  }
-}
-
-/* FIXME: can't handle dictionaries broken across multiple lines. Spec or not?
-class InlineDict extends MLModeHandler {
-  constructor(state, line, key, value) {
-    super("DICT", state);
-    this.depth = this.recalcDepth(state, line);
-    this.depth += state.stepWidth
-    this.concatted = [];
-    this.continue(state, value);
-    this.oneLiner = this.isEnd(state, value);
-    this.key = key;
-    state.stack.push(this);
-  }
-  continue(state, line) { this.concatted.push(line.trim()) }
-  isEnd(state, line) { return this.oneLiner || /.*}\s*$/m.test(line); }
-  endBlock(state, line) {
-    try{
-    if(!this.oneLiner) { this.continue(state, line) }
-    let source = this.concatted
-      .join('\n')
-      .match(/{(.*)}/)[1]
-      .trim()
-      .split(/,\s+/)
-      .map(_ => _.trimStart())
-      //.map(_ => ''.padStart(this.depth, ' ')+_);
-    state.stack.pop();
-    let parsed = yamlToDict(source);
-    log.info("ending block", this, "with", source, "resulting in", parsed)
-    state.stack.peek()[this.key] = parsed; 
-    //if (this.oneLiner) { return false; }
-    //else { return this.continue(state, line), true; }
-    } catch (e) {
-      console.error("error", e, "one liner?", this.oneLiner, "payload was", this.concatted);
-    }
-    return !this.oneLiner;
-  }
-}
-*/
-
-class DictMultiline extends MLModeHandler {
-  constructor(state, line, key, value) {
-    super("DICT", state);
-    this.depth = this.recalcDepth(state, line);
-    this.content = new FlexibleContainer(key, this.depth);
-    this.parentKey = key;
-    state.stack.peek()[key] = this.content;
-    state.stack.push(this);
-    this.previousStepWidth = state.stepWidth
-  }
-  continue(state, line) {
-    try {
-      this.recalcDepth(state, line);
-      state.stack.push(this.content);
-      parseYamlLine(state, line, this);
-    } finally {
-      if (state.stack.peek() == this.content) { state.stack.pop(); }
-    }
-  }
-  isEnd(state, line) { return this.lineDepth(line) <= this.depth; }
-  endBlock(state, line) {
-    state.stack.pop();
-    if (state.stack.peek() == this.content) state.stack.pop();
-    return state.stepWidth = this.previousStepWidth, false;
-  }
-}
-
-const SINGLE_QUOTED = /^'(.*)(?<!\\)'$/;
-const DOUBLE_QUOTED = /^"(.*)(?<!\\)"$/;
+const SINGLE_QUOTED = /'(.*)'/;
+const DOUBLE_QUOTED = /"(.*)"/;
 function unquote(value) {
   let quoted;
   if ((quoted = SINGLE_QUOTED.exec(value)) != null) { value = quoted[1].replaceAll("\\'", "'") }
   else if ((quoted = DOUBLE_QUOTED.exec(value)) != null) { value = quoted[1].replaceAll('\\"', '"') }
   return value;
+}
+
+/** Encapsulates transformation of a sequence of raw string tokens into one single string instance, folded, trimmed and chomped where needed. */
+class YamlString {
+  #token;
+  #style = 'FLOW'; //FLOW, (Block-)FOLD or (Block-)LITERAL
+
+  constructor(parentNode) { this.parent = parentNode; }
+  isEmpty() { return this.#token.trim().length == 0; }
+
+  get shiftLevel() {
+    if (this.#style == "FLOW") { return '+' }
+    if (typeof this.indentation == "number") { return this.parent[YAML.NESTING] + this.indentation; }
+    let m = null;
+    if ((m = /(?<=^|\n)[ \t]*(?=\S)/.exec(this.#token)) != null) { return m[0].length; }
+
+    return Math.max(0, ...this.#token.split('\n').map(l => l.length));
+  }
+
+  add(text) {
+    this.#token ||= '';
+    this.#token += text;
+  }
+
+  /*
+   * Applies the configuration / string styles to convert the raw array into a string, then returns the result.  
+   *
+   * To do so, the content must first be concatened, then modified in 4 locations, in the order below:
+   * 1. Remove 'structural' whitespace: Remove a number of blanks matching the indentation from the start of every line (a.k.a. 'shifting').
+   * 2. FOLD/FLOW: Remove trailing whitespaces per line and reduce subsequent empty lines by one.
+   * 3. Trailing whitespace AFTER content. Trimmed or chomped.
+   * 4. LITERAL: Keep shifted pre-content empty lines, trim in other styles.
+  */
+  get() {
+    if (this.isEmpty()) { return; }
+
+    let result = this.#token.replaceAll(/\r/g, '');
+
+    // 1. structural whitespace. In FLOW style, this includes ALL whitespace at a line's start
+    // for other styles, it depends on indentation and block header (handled by `get shiftLevel`)
+    let shiftLevel = this.shiftLevel.replace(/(\d+)/, '{$1}');
+    result = result.replace(r`/(?<=\n)[ \t]${shiftLevel}(?=\S)/g`, '');
+
+    // 2. Folding - the most confusing part of string handling
+    // It's different between FLOW and (Block-)FOLD, and FOLD also has a list of execeptions when
+    // strings are NOT folded (which are very confusing and contradictory)
+    if (this.#style == "FLOW") {
+      // first remove whitespace before and after content in FLOW
+      result = result
+        .replace(/(?<=^|\n)[ \t]+(?=\S)/g, '')
+        .replace(/(?<=\S)[ \t]+(?=\n|$)/g, '');
+    }
+    if (this.#style != "LITERAL") {
+      // now to the actual folding: convert singular \n between none-spaces to blanks
+      result = result.replace(/(?<=\S)\n(?=\S)/g, ' ');
+      // block folding has a set of special exceptions which can't fully be covered by regex on \n alone
+      // the hardest one is \n and empty lines following an indented line, which are not trimmed at all
+      // this will be handled by ADDING an additional \n at the right place (which will be stripped)
+      // by the next step again
+      if (this.#style == "FOLD") {
+        result = result.replace(/((^|\n)[ \t]+.*?\S[ \t]*\n)(\s*\n)(?![ \t])/g, '$1\n$3');
+      }
+      // remove \n which is followed by empty lines
+      result = result.replace(/(?<=\S)\n(\n+)(?!\s)/g, '$1');
+    }
+    return unquote(result);
+  }
 }
 
 /**
@@ -761,82 +947,6 @@ function handleValue(value) {
   try { return new PropValue(JSON.parse(value)); } catch (e) { }
   return new PropValue(unquote(value));
 }
-SINGLE_Q_W_COMMENT = /^('.*?(?<!\\)')([ ]+#.*)?$/;
-DOUBLE_Q_W_COMMENT = /^(".*?(?<!\\)")([ ]+#.*)?$/;
-function cleanYamlValue(value) {
-  if (value == null) { return null }
-  if (!value.includes('#')) { return value.trim() }
-
-  value = value.trim();
-  // # is included in quoted string
-  if (SINGLE_QUOTED.test(value) || DOUBLE_QUOTED.test(value)) { return value }
-
-  //either not quoted, or ["something" # comment]
-  let quoted;
-  if ((quoted = SINGLE_Q_W_COMMENT.exec(value)) != null) { return quoted[1] }
-  else if ((quoted = DOUBLE_Q_W_COMMENT.exec(value)) != null) { return quoted[1] }
-  //can only be unquoted
-  return value.split(/\s*#/)[0];
-}
-
-// regex madness
-// either match: 
-// - arbitrary none-newline characters between 2 identical quotes
-// - a single colon
-// - an arbitrary sequence of characters, starting from the first none-whitespace, up until colon and/or newline
-// this is not 100% spec - e.g. it can handle 'key: : sdt', which will result in value=': sdt'
-const OBJ_LINE = /^\s+|("[^"]*")|('[^']*')|:(?=\s+)|\S.*?(?=: |:$|\s*$)/gm;
-function parseYamlLine(state = {}, line = "") {
-  let handler = state.stack.peek();
-  if (handler instanceof MLModeHandler) {
-    if (handler.canSkip(line)) { return }
-    if (handler.isEnd(state, line)) {
-      if (handler.endBlock(state, line)) { return }
-      return state.lineDone = false;
-    } else return handler.continue(state, line);
-  }
-
-  let trimmed = line.trim();
-  switch (trimmed.charAt(0)) {
-    case '#': return
-    case '-': return new ListMultiline(state, line);
-  }
-
-  let whitespace = 0;
-  let ymlLine = line.trimEnd().match(OBJ_LINE) || [''];
-  // take care of leading whitespace and trailing \n
-  if (ymlLine[0].trim().length == 0) { whitespace = ymlLine.shift().length }
-  if (ymlLine.lastIndexOf('\n') == ymlLine.length - 1) { ymlLine.pop() }
-  if (ymlLine.length < 2 || ymlLine[1] != ':') { return log.trace('skip line [%s]: "%s"', state.line, line) }
-
-  if (ymlLine.length > 3) {
-    let tempLine = line;
-    tempLine = tempLine.slice(tempLine.indexOf(ymlLine[0]) + ymlLine[0].length);
-    tempLine = tempLine.slice(tempLine.indexOf(ymlLine[1]) + ymlLine[1].length);
-    ymlLine[2] = tempLine.slice(tempLine.indexOf(ymlLine[2]));
-  }
-
-  let subDict = state.stack.peek();
-  if (whitespace <= subDict[Symbol.for("depth")]) {
-    state.stack.pop();
-    return state.lineDone = false
-  }
-
-  let key = handleValue(ymlLine[0].trim());
-  let value = cleanYamlValue(ymlLine[2] || '');
-  trimmed = `${ymlLine[2]}:${value}`.trim();
-  if (trimmed.endsWith(':')) { return new DictMultiline(state, line, key, value) }
-  else if (value != null && value.length > 0) {
-    value = value.trim();
-    switch (value.charAt(0)) {
-      case '|': return new StringMultiline(state, line, key);
-      case '[': return new ArrayMultiline(state, line, key, value);
-      //case '{': return new InlineDict(state, line, key, value);
-      default: try { value = handleValue(value); } catch (e) { }
-    }
-    subDict[key] = value;
-  }
-}
 
 /** @endsection */
 
@@ -846,7 +956,7 @@ module.exports = {
   parseDict, analyseProperty,
   SOURCE_FILE,
   // expose the parse functions themselves for places where the type is know, but not matching the extension
-  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict,
+  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict, yamlToDict_IMPL,
   //for information/API puposes
   FORMATS,
   XML,

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -254,279 +254,8 @@ function yamlToDict(yamlFile) {
   return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
 }
 
-/**
- * Utilities to handle the complex parser state when parsing yaml.
- * Methods of this object will be called with `this` set to the instance of the current `ParseContext`.
- */
-class ParseContext {
-  #STACK = []
-
-  get root() { return this.#STACK[0]; }
-  get current() { return this.#STACK.at(-1); }
-  get previous() { return this.#STACK.at(-2); }
-
-  /** 
-   * `this` is normally lost when methods are used as callbacks.
-   * This method overrides that by assigning a bound variant of the class method as instance property.
-   * Passing the instance property as callback means passing a pre-bound function.
-   */
-  bindFunctions() {
-    Object.values(Object.getOwnPropertyDescriptors(Object.getPrototypeOf(this))).forEach(v => {
-      v = v.value;
-      if (typeof v == "function") { this[v.name] = v.bind(this) }
-    });
-  }
-
-  start(parser) {
-    this.parser = parser;
-    this.#STACK = [new UniversalNode('#root')];
-  }
-
-  enterNode(name, raw = name) {
-    let node = new UniversalNode(name, raw);
-    this.current.subNode(name, node);
-    this.#STACK.push(node);
-    console.error('\t--> ENTER', this.current.tagName())
-  }
-
-  addChildNode(tag) {
-    let node = new UniversalNode(tag);
-    this.current.content(node)
-    this.#STACK.push(node);
-    console.error('\t--> PUSH CHILD:', tag)
-  }
-
-  nodeHeaderDone(raw) { this.current.headerDone(raw); }
-
-  // leave node
-  leaveNode(raw) {
-    console.error('\t--> LEAVE', this.current.tagName(), this.current)
-    this.current.addRaw(raw, true);
-    this.#STACK.pop();
-  }
-
-  addContent(text, raw) { this.current.content(text, raw); }
-}
-
-class YAML extends ParseContext {
-  // PARSE_MODES is not actively used (referenced in the code)
-  static PARSE_MODES = ['BLOCK', 'FLOW']
-  // something like a 'sub-category' of parse modes
-  static PARSE_PHASES = ['ENTRY', 'TOKEN', 'TOKEN:ML']
-  static BLOCK_H_STYLES = { '|': "LITERAL", '>': "FOLD" }
-  static CHOMP_MODES = { '+': 'KEEP', '-': 'STRIP', '': 'CLIP'}
-
-  static CNEST = Symbol.for('CNEST');
-  static NESTING = Symbol.for('NESTING');
-  static MODE = Symbol.for('MODE');
-  static PHASE = Symbol.for('PHASE');
-  static TOKEN = Symbol.for('TOKEN');
-
-  cleanNode() { Object.getOwnPropertySymbols(this.current).forEach(k => delete this.current[k]); }
-  pushNextNode(tagName, isSubNode) {
-    if (typeof isSubNode == "undefined") { isSubNode = tagName ? String(tagName).length > 0 : false; }
-    let factory = isSubNode ? this.enterNode : this.addChildNode;
-    factory.call(this, tagName);
-    this.inheritStateProperties();
-    this.current[YAML.PHASE] = "ENTRY";
-    delete this.previous[YAML.PHASE];
-  }
-  inheritStateProperties() {
-    this.current[YAML.MODE] = this.previous[YAML.MODE] || 'BLOCK';
-    this.current[YAML.NESTING] = this.previous[YAML.CNEST];
-    console.error(
-      `\t--> INHERIT ${this.current.tagName()}:`, this.current[YAML.NESTING], '->', this.current[YAML.MODE],
-      `from:`, this.previous.tagName(), this.previous[YAML.NESTING], this.previous[YAML.CNEST]
-    );
-  }
-
-  hasToken() { return typeof this.state(YAML.TOKEN) != "undefined"; }
-  handleToken(match, rule) {
-    // when coming from parser directly, the first group will be token content
-    // otherwise it could be called from another method with a pre-processed string
-    match = Array.isArray(match) ? match[1] : match;
-    let token = (this.current[YAML.TOKEN] ||= new YamlToken(this.current));
-    if(token.isEmpty() && ['DQ', 'SQ'].includes(rule.getId())) { token.quoteMode = rule.getId(); }
-    token.add(match);
-    switch (this.state(YAML.PHASE)) {
-      case "ENTRY":
-        if (!token.isEmpty()) { this.state(YAML.PHASE, "TOKEN"); }
-        break;
-      case "TOKEN":
-        this.state(YAML.PHASE, "TOKEN:ML");
-        break;
-    }
-  }
-  consumeToken() {
-    if (!this.hasToken()) { return; }
-
-    let result = this.state(YAML.TOKEN).get();
-    delete this.current[YAML.TOKEN];
-    delete this.current[YAML.PHASE];
-    return result;
-  }
-
-  tokenToContent() {
-    let token = this.consumeToken();
-    if (typeof token == "undefined") { return }
-
-    console.error('\t--> ASSIGN TOKEN', token);
-    this.addContent(handleValue(token));
-  }
-
-  enterFlow(flowNodeMarker) {
-    this.pushNextNode('#FLOW:ROOT', false);
-    this.current[YAML.MODE] = 'FLOW';
-    if (flowNodeMarker[0].trim() == "[") { this.current.setContentMode("ARRAY"); }
-    if (this.current.getContentMode() == "ARRAY") {
-      this.pushNextNode('#ARR-ENTRY', false);
-    }
-  }
-
-  closeFlow(match) {
-    let term = match[0].replace(/\s+/gm, '');
-    if (term == ',') {
-      this.current.getContentMode() == "ARRAY" ? this.tokenToContent() : this.finishCurrentNode();
-      return;
-    }
-
-    this.finishCurrentNode();
-    if (!this.previous) { return; }
-    console.error('\t    MODES (p,c)', this.previous[YAML.MODE], this.current[YAML.MODE])
-    if (this.current.tagName() == "#FLOW:ROOT") { this.finishCurrentNode(); }
-  }
-
-  handleOperator(op, reg, source) {
-    op = op[0];
-    switch (op.charAt(0)) {
-      case ':':
-        let token = this.consumeToken();
-        this.pushNextNode(token);
-        break;
-      case '|':
-      case '>':
-        let tokenStyle = YAML.BLOCK_H_STYLES[op.charAt(0)];
-        let token = new YamlToken(this.current, tokenStyle);
-        this.state(YAML.TOKEN, token);
-        token.chomping = YAML.CHOMP_MODES[op.replace(/[^+-]/g, '')];
-        token.nesting = op.replace(/[^\d]/g, '');
-    }
-  }
-
-  markArray(depth, addChild = true) {
-    depth = Number(depth) || 2;
-    console.error("\t--> MARK ARRAY:", this.current.tagName(), 'N:', this.state(YAML.NESTING), 'CN:', this.current[YAML.CNEST]);
-    if (this.current.getContentMode() != "ARRAY") {
-      this.pushNextNode(this.current.tagName() + '[]', false);
-      this.state(YAML.NESTING, this.previous[YAML.NESTING]);
-      this.state(YAML.CNEST, this.previous[YAML.CNEST]);
-      this.current.setContentMode("ARRAY");
-    }
-
-    if (addChild) {
-      this.pushNextNode(this.current.tagName() + '#' + this.current.getContentLength(), false);
-      this.state(YAML.CNEST, this.state(YAML.NESTING) + depth);
-    }
-  }
-
-  finishCurrentNode() {
-    this.tokenToContent();
-    this.cleanNode();
-    this.leaveNode();
-  }
-
-  state(state, value, node) {
-    node ||= this.current;
-    if (value == undefined) { return node[state]; }
-    node[state] = value;
-    console.error(`\t--> ${Symbol.keyFor(state)} ${value} >>> ${node.tagName()}`)
-  }
-
-  /** Only SET value if state is not set already */
-  stateOnce(state, value, node) {
-    node ||= this.current;
-    if (typeof value == "undefined") { throw "stateOnce() must receive a value argument" }
-    if (typeof node[state] == "undefined") { this.state(state, value, node); }
-  }
-
-  closeNodes(depthMatch) {
-    let regD = depthMatch[1].length;
-    let arrD = regD;
-    if (depthMatch[0].trim().endsWith('-')) {
-      arrD += 2;
-      this.parser.lastIndex -= 2;
-    }
-    while (true) {
-      if (arrD > regD && arrD > this.state(YAML.NESTING) && "ENTRY" == this.state(YAML.PHASE)) {
-        this.state(YAML.CNEST, regD);
-        this.markArray(arrD - regD, false);
-      }
-      let diff = this.state(YAML.NESTING) - (this.current.getContentMode() == "ARRAY" ? arrD : regD);
-      console.error("\t--> RCL:" + this.current.tagName(), 'N:', this.current[YAML.NESTING], 'D:', diff, regD, arrD)
-
-      if (diff >= 0) { this.finishCurrentNode(depthMatch); }
-      else { break; }
-    }
-    this.stateOnce(YAML.CNEST, arrD);
-    //save whitespace for unquoted multiline Strings
-    this.handleToken(depthMatch[0].substring(0, regD + 1));
-  }
-}
-
 function yamlToDict_IMPL(yamlFile) {
-  return readTextPropertyFile(yamlFile, sourceText => {
-
-    let yaml = new YAML();
-    yaml.bindFunctions();
-
-    function isMode(m, isIncluded = true) { return () => m.includes(yaml.current[YAML.MODE]) == isIncluded; }
-    function isPhase(p, isIncluded = true) { return () => p.includes(yaml.current[YAML.PHASE]) == isIncluded; }
-
-    let R = new RegexDocParser({
-      // NOOP: Comments - (at least) one whitespace followed by whatever up to the next \n.
-      // only allowed while not in the middle of a multiline token, treat it as regular content otherwise
-      LC: [/(?:^|\s)+#.*?(?=$)/m, false, isPhase(["TOKEN:ML"], false)],
-      // Empty lines
-      EL: [/\n[ \t]*(?=\n|$)/m, yaml.handleToken],
-      'BL:ARR': [/(-)(?=\s)/, yaml.markArray, isMode('BLOCK')],
-      // From " on anything up until the first unescaped " (unescaped: no uneven number of slashes before it)
-      // can run over multiple lines.
-      DQ: [/("(?:\\\\|\\"|\\[^"]|[^\\"])*")/m, yaml.handleToken],
-      // single quoted tokens
-      SQ: [/('(?:''|[^'])*')/m, yaml.handleToken],
-      // block scalar indicators
-      'BL:SLH': [/([|>]|[|>][+-]\d|[|>]\d[+-])(?=[ \t\n])/, yaml.handleOperator, isMode('BLOCK')],
-      // indicators which are not allowed in unquoted tokens
-      OP: [/([:?](?=[ \t\n]))/, yaml.handleOperator],
-      // indicators/operators belonging to flow mode: [], {}, ','
-      'FL:OP': [/\{|\[/, yaml.enterFlow],
-      'FL:X': [/\s*(?:,[ \t]*\}|,[ \t]*\]|[,\}\]])/, yaml.closeFlow, isMode('FLOW')],
-      // unquoted in FLOW mode has additional terminators `,`, `}` and `]`
-      'NQ:FL': [/(\S.*?)(?=[:?-]\s|[\]\},]|\s#|\n)/, yaml.handleToken, isMode('FLOW')],
-      // any unquoted one-liner, up to the first indicator or linebreak
-      // note: might have issues at end of file - requires an additional space or \n
-      NQ: [/(\S.*?)(?=[:?-]\s|\s#|\n|$)/, yaml.handleToken],
-      // the whitespace at the beginning of a line which controls when to leave a nested level
-      DPT: [/(?:^|\n)([ \t]*)(-\s)?(?=[^\-\n]|\S)/m, yaml.closeNodes, isMode('BLOCK')],
-      // In FLOW, only take the leading whitespaces as parts of the token, they are not used for closing.
-      'DPT:FL': [/(\n\s*)/, yaml.handleToken, isMode('FLOW')],
-      // NOOP: trailing whitespace from payload up to the next \n
-      TRAIL: [/[ \t]+(?=\S|\n|$)/m, () => { }]
-    }, true);
-
-    yaml.start(R);
-    yaml.current[YAML.NESTING] = -1;
-    yaml.current[YAML.MODE] = 'BLOCK';
-    try {
-      R.exec(sourceText);
-      yaml.closeNodes(["", ""]);
-      yaml.cleanNode();
-
-    } finally {
-      console.error(JSON.stringify(yaml.root.valueOf(), null, 2))
-    }
-    return yaml.current.valueOf();
-  }, CONTENT_PROVIDER.DIRECT, false);
+  return readTextPropertyFile(yamlFile, YAML.parse, CONTENT_PROVIDER.DIRECT, false);
 }
 
 const FOLDER_SPEC = /^\w+(\.folder\[(".*?")\/?\]).*=.*/;
@@ -558,7 +287,7 @@ function analyseProperty(propLine) {
 /**
  * @section Generic parser infrastructure
  * @description
- * The following functions and classes provide basic plumbing and utility for all type-specific parsing implementations.
+ * The following functions and classes provide basic plumbing and utility for all type-specific parser implementations.
  */
 
 /**
@@ -599,11 +328,12 @@ class RegexDocParser extends RegExp {
 
     let m = reg.exec(sourceText, diag);
     if (m == null) { return false; }
+    // skip empty matches
+    if (m.indices[0][1] - m.indices[0][0] == 0) { return false; }
 
     let result = action
       ? action(m, reg, sourceText) || true
       : true;
-    this.previousMatch = m;
     return result;
   }
   static #traverseSource(shared, sourceText) {
@@ -645,7 +375,7 @@ class RegexDocParser extends RegExp {
 
   getId() { return this.#id; }
   reset() { this.#state.lastIndex = 0; }
-  
+
   exec(sourceText, diag) {
     let currentLast = this.#state.lastIndex;
     this.lastIndex = currentLast;
@@ -675,6 +405,60 @@ class RegexDocParser extends RegExp {
 }
 
 /**
+ * Utilities to handle the complex parser state when parsing yaml.  
+ * Methods of this object will be called with `this` set to the instance of the current `ParseContext`.
+ */
+class ParseContext {
+  #STACK = []
+
+  get root() { return this.#STACK[0]; }
+  get current() { return this.#STACK.at(-1); }
+  get previous() { return this.#STACK.at(-2); }
+
+  /** 
+   * `this` is normally lost when methods are used as callbacks.
+   * This method overrides that by assigning a bound variant of the class method as instance property.
+   * Passing the instance property as callback means passing a pre-bound function.
+   */
+  bindFunctions() {
+    Object.values(Object.getOwnPropertyDescriptors(Object.getPrototypeOf(this))).forEach(v => {
+      v = v.value;
+      if (typeof v == "function") { this[v.name] = v.bind(this) }
+    });
+  }
+
+  start(parser) {
+    this.parser = parser;
+    this.#STACK = [new UniversalNode('#root')];
+  }
+
+  enterNode(name, raw = name) {
+    let node = new UniversalNode(name, raw);
+    this.current.subNode(name, node);
+    this.#STACK.push(node);
+    console.error('\t--> ENTER', this.current.tagName)
+  }
+
+  addChildNode(tag) {
+    let node = new UniversalNode(tag);
+    this.current.content(node)
+    this.#STACK.push(node);
+    console.error('\t--> PUSH CHILD:', tag)
+  }
+
+  nodeHeaderDone(raw) { this.current.headerDone(raw); }
+
+  // leave node
+  leaveNode(raw) {
+    console.error('\t--> LEAVE', this.current.tagName, this.current)
+    this.current.addRaw(raw, true);
+    this.#STACK.pop();
+  }
+
+  addContent(text, raw) { this.current.content(text, raw); }
+}
+
+/**
  * To be used in conjunction with [class RegexDocParser](#class_regexdocparser).
  * 
  * This class represents one node of any type in the parsed tree. Its basic capabilities are inspired by the structure produced by `xmlToDict`.
@@ -694,7 +478,6 @@ class RegexDocParser extends RegExp {
  * Refer to [valueOf()](#class_universalnode_valueof) for details.
  */
 class UniversalNode {
-  #tagName;
   #rawValues = []
   #rawContentIndices = []
   #subNodes = {}
@@ -704,7 +487,7 @@ class UniversalNode {
   static realValue(obj) { return (obj instanceof UniversalNode) ? obj.valueOf() : obj; }
 
   constructor(tag, raw) {
-    this.#tagName = tag;
+    this.tagName = tag;
     this.#rawValues.push(raw);
   }
 
@@ -716,7 +499,6 @@ class UniversalNode {
   getContentMode() { return this.#contentMode; }
 
   // some small getter utils
-  tagName() { return this.#tagName; }
   hasContent() { return this.#content.length > 0; }
   getContentLength() { return this.#content.length; }
   isMixed() { return this.hasContent() && Object.keys(this.#subNodes).length > 0 }
@@ -780,10 +562,16 @@ class UniversalNode {
 /** @endsection */
 
 /**
- * @section INTERNAL SUPPORT CLASSES AND FUNCTIONS
- * @description
- * Most of the classes and functions following this block are for parsing yml files
- * as this is the most complex format.
+ * @section Internal support classes and functions
+ * @description The code in this section completely generic.  
+ * It is used by the generic parser infrastructure, but also by other, simpler parser implementations.
+ */
+
+/**
+ * Main entrance to all parser functions. It provides top-level handling of:
+ * - Basic debug logging
+ * - Handling of global state `CURRENT_FILE` for PropValue. Parsers depending on this are not 'thread-safe'.
+ * - Errors: log exceptions and throw
  */
 function readTextPropertyFile(confFile, dataLinesCallback, contentProvider = CONTENT_PROVIDER.DIRECT, ...providerArgs) {
   if (Array.isArray(confFile)) { return dataLinesCallback(confFile); }
@@ -804,7 +592,10 @@ function readTextPropertyFile(confFile, dataLinesCallback, contentProvider = CON
   if (failure) { throw failure; }
 }
 
-/** To be used as a tag function for building regexes dynamically. Backslashes can be used as in literal RegExp with `/.../`, no escaping needed. */
+/**
+ * To be used as a tag function for building regexes dynamically.  
+ * Backslashes can be used as in literal RegExp with `/.../`, no escaping needed. 
+ */
 function r(constants, ...paras) {
   let raw = constants.raw.map(e => e + (paras.shift() || '')).join('');
   if (raw.startsWith('/')) {
@@ -815,13 +606,255 @@ function r(constants, ...paras) {
   return new RegExp(raw);
 }
 
-/** YAML FILES */
-const QUOTE_MATCHER = /^(["'])(.*)\1$/s
-function unquote(value, unmask=true){
+const QUOTE_MATCHER = /^\s*(["'])(.*)\1\s*$/s
+/** 
+ * Unquote any **content** string enclosed in either `"` or `'` and returns the true inner string value.  
+ * By default, the character used to as quotation is also unmasked (if it is by an uneven number of \).  
+ * Quote unmasking can be disabled by passing false as second parameter.
+ */
+function unquote(value, unmask = true) {
   let matched = QUOTE_MATCHER.exec(value);
   if (matched == null) { return value; }
-  if(unmask) { return matched[2].replace(r`\\${matched[1]}`, matched[1]); }
+  if (unmask) { return matched[2].replace(r`(?<=^|[^\\](?:\\\\)*)\\${matched[1]}`, matched[1]); }
   else { return matched[2]; }
+}
+
+function handleValue(value) {
+  try { return new PropValue(JSON.parse(value)); } catch (e) { }
+  return new PropValue(unquote(value));
+}
+
+/**
+ * Helper class that can be used to transport meta-information about the origin of a property.
+ * Most use cases shouldn't care because of the valueOf implementation and just behave as if it was a string.
+ * One notable exception is default initialisation by existence checks.
+ */
+class PropValue {
+  constructor(val, source = CURRENT_FILE) {
+    this.value = val;
+    this.source = source;
+  }
+
+  toJSON() { return this.value }
+  valueOf() { return this.value }
+  toString() { return String(this.value) }
+}
+
+/** @endsection */
+
+/**
+ *  @section YAML-specific code
+ */
+class YAML extends ParseContext {
+  static BLOCK_H_STYLES = { '|': "LITERAL", '>': "FOLD" }
+  static CHOMP_MODES = { '+': 'KEEP', '-': 'STRIP', '': 'CLIP' }
+
+  static CNEST = Symbol.for('CNEST');
+  static NESTING = Symbol.for('NESTING');
+  /** BLOCK or FLOW */
+  static MODE = Symbol.for('MODE');
+  /** ENTRY, TOKEN, TOKEN:ML */
+  static PHASE = Symbol.for('PHASE');
+  static TOKEN = Symbol.for('TOKEN');
+
+  static parse(sourceText) {
+    let yaml = new YAML();
+    yaml.bindFunctions();
+
+    function isMode(m, isIncluded = true) { return () => m.includes(yaml.current[YAML.MODE]) == isIncluded; }
+    function isPhase(p, isIncluded = true) { return () => p.includes(yaml.current[YAML.PHASE]) == isIncluded; }
+
+    let R = new RegexDocParser({
+      // NOOP: Comments - (at least) one whitespace followed by whatever up to the next \n.
+      // only allowed while not in the middle of a multiline token, treat it as regular content otherwise
+      LC: [/(?:^|\s)+#.*?(?=$)/m, false, isPhase(["TOKEN:ML"], false)],
+      // Empty lines
+      EL: [/(\n[ \t]*)(?=\n|$)/, yaml.handleToken],
+      'BL:ARR': [/(-)(?=\s)/, yaml.markArray, isMode('BLOCK')],
+      // From " on anything up until the first unescaped " (unescaped: no uneven number of slashes before it)
+      // can run over multiple lines.
+      DQ: [/("(?:\\\\|\\"|\\[^"]|[^\\"])*")/m, yaml.handleToken],
+      // single quoted tokens
+      SQ: [/('(?:''|[^'])*')/m, yaml.handleToken],
+      // block scalar indicators
+      'BL:SLH': [/([|>](?:[+-]\d?|\d[+-]?)|[|>])(?=[ \t\n])/, yaml.handleOperator, isMode('BLOCK')],
+      // indicators which are not allowed in unquoted tokens
+      OP: [/([:?](?=[ \t\n]))/, yaml.handleOperator],
+      // indicators/operators belonging to flow mode: [], {}, ','
+      'FL:OP': [/\{|\[/, yaml.enterFlow],
+      'FL:X': [/\s*(?:,[ \t]*\}|,[ \t]*\]|[,\}\]])/, yaml.closeFlow, isMode('FLOW')],
+      // unquoted in FLOW mode has additional terminators `,`, `}` and `]`
+      'NQ:FL': [/(\S.*?)(?=[:?-]\s|[\]\},]|\s#|\n)/, yaml.handleToken, isMode('FLOW')],
+      // any unquoted one-liner, up to the first indicator or linebreak
+      // note: might have issues at end of file - requires an additional space or \n
+      NQ: [/(\S.*?)(?=[:?-]\s|\s#|\n|$)/, yaml.handleToken],
+      // the whitespace at the beginning of a line which controls when to leave a nested level
+      DPT: [/(?:^|\n)([ \t]*)(-\s)?(?=[^\-\n]|\S)/, yaml.closeNodes, isMode('BLOCK')],
+      // In FLOW, only take the leading whitespaces as parts of the token, they are not used for closing.
+      'DPT:FL': [/(\n\s*)/, yaml.handleToken, isMode('FLOW')],
+      // NOOP: trailing whitespace from payload up to the next \n
+      TRAIL: [/([ \t]+)(?=\S|\n|$)/m, yaml.handleToken]
+    }, true);
+
+    yaml.start(R);
+    yaml.current[YAML.NESTING] = -1;
+    yaml.current[YAML.MODE] = 'BLOCK';
+
+    R.exec(sourceText);
+    yaml.closeNodes(["", ""]);
+    yaml.cleanNode();
+
+    return yaml.root.valueOf();
+  }
+
+  cleanNode() { Object.getOwnPropertySymbols(this.current).forEach(k => delete this.current[k]); }
+  pushNextNode(tagName, isSubNode) {
+    if (typeof isSubNode == "undefined") { isSubNode = tagName ? String(tagName).length > 0 : false; }
+    let factory = isSubNode ? this.enterNode : this.addChildNode;
+    factory.call(this, tagName);
+    this.inheritStateProperties();
+    this.current[YAML.PHASE] = "ENTRY";
+    delete this.previous[YAML.PHASE];
+  }
+  inheritStateProperties() {
+    this.current[YAML.MODE] = this.previous[YAML.MODE] || 'BLOCK';
+    this.current[YAML.NESTING] = this.previous[YAML.CNEST] || 0;
+    console.error(
+      `\t--> INHERIT ${this.current.tagName}:`, this.current[YAML.NESTING], '->', this.current[YAML.MODE],
+      `from:`, this.previous.tagName, this.previous[YAML.NESTING], this.previous[YAML.CNEST]
+    );
+  }
+
+  hasToken() { return typeof this.state(YAML.TOKEN) != "undefined"; }
+  handleToken(match, rule = null) {
+    // when coming from parser directly, the first group will be token content
+    // otherwise it could be called from another method with a pre-processed string
+    match = Array.isArray(match) ? match[1] : match;
+    let token = (this.current[YAML.TOKEN] ||= new YamlToken(this.current));
+    if (token.isEmpty() && rule != null && ['DQ', 'SQ'].includes(rule.getId())) { token.quoteMode = rule.getId(); }
+    token.add(match);
+    switch (this.state(YAML.PHASE)) {
+      case "ENTRY":
+        if (!token.isEmpty()) { this.state(YAML.PHASE, "TOKEN"); }
+        break;
+      case "TOKEN":
+        this.state(YAML.PHASE, "TOKEN:ML");
+        break;
+    }
+  }
+  consumeToken() {
+    if (!this.hasToken()) { return; }
+
+    let result = this.state(YAML.TOKEN).get();
+    delete this.current[YAML.TOKEN];
+    delete this.current[YAML.PHASE];
+    return result;
+  }
+
+  tokenToContent() {
+    let token = this.consumeToken();
+    if (typeof token == "undefined") { return }
+
+    console.error('\t--> ASSIGN TOKEN', token);
+    this.addContent(new PropValue(token));
+  }
+
+  enterFlow(flowNodeMarker) {
+    this.pushNextNode('#FLOW:ROOT', false);
+    this.current[YAML.MODE] = 'FLOW';
+    if (flowNodeMarker[0].trim() == "[") { this.current.setContentMode("ARRAY"); }
+    if (this.current.getContentMode() == "ARRAY") {
+      this.pushNextNode('#ARR-ENTRY', false);
+    }
+  }
+
+  closeFlow(match) {
+    let term = match[0].replace(/\s+/gm, '');
+    if (term == ',') {
+      this.current.getContentMode() == "ARRAY" ? this.tokenToContent() : this.finishCurrentNode();
+      return;
+    }
+
+    this.finishCurrentNode();
+    if (!this.previous) { return; }
+    console.error('\t    MODES (p,c)', this.previous[YAML.MODE], this.current[YAML.MODE])
+    if (this.current.tagName == "#FLOW:ROOT") { this.finishCurrentNode(); }
+  }
+
+  handleOperator(op) {
+    op = op[0];
+    switch (op.charAt(0)) {
+      case ':':
+        this.pushNextNode(this.consumeToken());
+        break;
+      case '|':
+      case '>':
+        let tokenStyle = YAML.BLOCK_H_STYLES[op.charAt(0)];
+        let token = new YamlToken(this.current, tokenStyle);
+        this.state(YAML.TOKEN, token);
+        token.chomping = YAML.CHOMP_MODES[op.replace(/[^+-]/g, '')];
+        token.nesting = op.replace(/[^\d]/g, '');
+    }
+  }
+
+  markArray(depth, addChild = true) {
+    depth = Number(depth) || 2;
+    console.error("\t--> MARK ARRAY:", this.current.tagName, 'N:', this.state(YAML.NESTING), 'CN:', this.current[YAML.CNEST]);
+    if (this.current.getContentMode() != "ARRAY") {
+      this.pushNextNode(this.current.tagName + '[]', false);
+      this.state(YAML.NESTING, this.previous[YAML.NESTING]);
+      this.state(YAML.CNEST, this.previous[YAML.CNEST]);
+      this.current.setContentMode("ARRAY");
+    }
+
+    if (addChild) {
+      this.pushNextNode(this.current.tagName + '#' + this.current.getContentLength(), false);
+      this.state(YAML.CNEST, this.state(YAML.NESTING) + depth);
+    }
+  }
+
+  finishCurrentNode() {
+    this.tokenToContent();
+    this.cleanNode();
+    this.leaveNode();
+  }
+
+  state(state, value, node) {
+    node ||= this.current;
+    if (value == undefined) { return node[state]; }
+    node[state] = value;
+    console.error(`\t--> ${Symbol.keyFor(state)} ${value} >>> ${node.tagName}`)
+  }
+
+  /** Only SET value if state is not set already */
+  stateOnce(state, value, node) {
+    node ||= this.current;
+    if (typeof value == "undefined") { throw "stateOnce() must receive a value argument" }
+    if (typeof node[state] == "undefined") { this.state(state, value, node); }
+  }
+
+  closeNodes(depthMatch, rule) {
+    let regD = depthMatch[1].length;
+    let arrD = regD;
+    if (depthMatch[0].trim().endsWith('-')) {
+      arrD += 2;
+      this.parser.lastIndex -= 2;
+    }
+    while (true) {
+      if (arrD > regD && arrD > this.state(YAML.NESTING) && "ENTRY" == this.state(YAML.PHASE)) {
+        this.state(YAML.CNEST, regD);
+        this.markArray(arrD - regD, false);
+      }
+      let diff = this.state(YAML.NESTING) - (this.current.getContentMode() == "ARRAY" ? arrD : regD);
+      console.error("\t--> RCL:" + this.current.tagName, 'N:', this.current[YAML.NESTING], 'D:', diff, regD, arrD)
+
+      if (diff >= 0) { this.finishCurrentNode(depthMatch); }
+      else { break; }
+    }
+    this.stateOnce(YAML.CNEST, arrD);
+    //save whitespace for unquoted multiline Strings
+    this.handleToken(depthMatch[0].substring(0, regD + 1), rule);
+  }
 }
 
 /** 
@@ -837,10 +870,8 @@ function unquote(value, unmask=true){
  * 5. When done, retrieve the value with `YamlToken.get()`.
  */
 class YamlToken {
-  static JSON_MASKING = {
-    '\n': '\\n',
-    '\t': '\\t'
-  }
+  static JSON_MASKING = { '\n': '\\n', '\t': '\\t' }
+
   #style = 'FLOW'; //FLOW, (Block-)FOLD or (Block-)LITERAL
   #quoting = 'NQ'; // DQ, SQ, NQ; for FLOW only
   #chompMode = 'CLIP'; // STRIP, CLIP, KEEP
@@ -849,17 +880,17 @@ class YamlToken {
   #token;
   #trailing;
 
-  constructor(parentNode, style) { 
-    this.parent = parentNode; 
-    this.#style = style;
+  constructor(parentNode, style) {
+    this.parent = parentNode;
+    this.#style = style || this.#style;
   }
   isEmpty() { return (typeof this.#token == "undefined") || this.#token.trim().length == 0; }
 
-  set chomping(style){ this.#chompMode = style; }
+  set chomping(style) { this.#chompMode = style; }
   set quoteMode(mode = "NQ") { this.#quoting = mode; }
   set indentation(raw) {
     let n = parseInt(raw);
-    if(Number.isNaN(n) || n < 1) { delete this.#indent; }
+    if (Number.isNaN(n) || n < 1) { this.#indent = undefined; }
     else this.#indent = n;
   }
 
@@ -867,8 +898,8 @@ class YamlToken {
     if (this.#style == "FLOW") { return '+' }
     if (typeof this.#indent == "number") { return this.parent[YAML.NESTING] + this.#indent; }
 
-    // YAML 1.2.2 - 8.1.1.1 Block Indentation Indicator
     let m = null;
+    // YAML 1.2.2 - 8.1.1.1 Block Indentation Indicator
     // 1. whitespace prefix of first none-empty line
     if ((m = /(?<=^|\n)[ \t]*(?=\S)/.exec(this.#token)) != null) { return m[0].length; }
     // 2. Longest empty line
@@ -895,10 +926,11 @@ class YamlToken {
    *   d) assume string for everything else
   */
   get() {
+    console.error("\t--> GET-TK:", this.#style, this.#quoting, this.indentation, this.#chompMode, '\n', JSON.stringify(this.#token));
     if (this.isEmpty()) { return; }
 
     // 1. Basic normalization and structural cleaning
-    let result= this.#sanitizedToken();
+    let result = this.#sanitizedToken();
 
     // 2. Folding - the most confusing part of string handling
     // It's different between FLOW and (Block-)FOLD, and FOLD also has a list of execeptions when
@@ -914,7 +946,7 @@ class YamlToken {
     // 3. Squashing of empty lines
     if (this.#style != "LITERAL") { result = this.#handleFolding(result); }
     // 4. Chomp
-    switch(this.#chompMode){
+    switch (this.#chompMode) {
       case 'CLIP': result += this.#trailing.length > 0 ? '\n' : ''; break;
       case 'KEEP': result += this.#trailing; break;
     }
@@ -932,7 +964,7 @@ class YamlToken {
    *    Subsequent logic won't have to deal with 'empty lines', so folding is mostly identical for FLOW and FOLD.
    * 3. **Empty** trailing newlines are removed and stashed away into `#trailing`
    */
-  #sanitizedToken(){
+  #sanitizedToken() {
     let result = this.#token.normalize('NFC').replaceAll(/\r/g, '');
 
     // Structural whitespace
@@ -942,7 +974,7 @@ class YamlToken {
 
     //stash and drop trailing lines from the last content char (last character which is NOT `\n`) to end of string
     this.#trailing = /(?<!\n)(\n*)?$/.exec(result)[1] || '';
-    if(this.#trailing.length > 0){ result = result.slice(0, -this.#trailing.length); }
+    if (this.#trailing.length > 0) { result = result.slice(0, -this.#trailing.length); }
 
     return result;
   }
@@ -958,7 +990,7 @@ class YamlToken {
    */
   #prepareFlow(result) {
     this.#chompMode = "STRIP";
-    switch(this.#quoting){
+    switch (this.#quoting) {
       // Drop 'escaped' `\n` - these are yaml helpers to break the source without adding LFs to content.
       // Other escape sequences will be dealt with by `JSON.parse(...)`,
       // which is why the " surrounding the string must not be removed.
@@ -980,25 +1012,27 @@ class YamlToken {
    * 1. Convert singular newlines to spaces
    * 2. Squash subsequent newlines (and 'empty' lines) where applicable (some exception for block in `FOLD` style)
    */
-  #handleFolding(result){
+  #handleFolding(result) {
     // YAML 1.2.2 - (Block Scalar) 8.1.3. Folded Style
     // Deal with the none-folded exceptions by ADDING an additional `\n`, which will be stripped by the next step again.
     // This is easier to detect than excluding the exceptions from the generic line folding used below.
     if (this.#style == "FOLD") {
-      //A line starting with at least one space, which is followed by (at least) one empty line
-      result = result.replace(/(?<=^|\n)([ \t].*?\n)(\n+)(?!\n)/g, '$1\n$2');
+      //A line starting with at least one content space, plus (optionally) more empty lines, followed by none-space
+      //-> deeper nested line + linebreaks + 'unnested' content
+      result = result.replace(/(?<=^|\n)([ \t].*?\n)(\n*)(?=\S)/g, '$1\n$2');
     }
     // YAML 1.2.2 - 6.5. Line Folding
     return result
-      // 1. Convert singular `\n` between none-spaces to blanks (implicitely excludes the FOLD-exception `\n[space]`).
-      .replace(/(?<=\S)\n(?=\S)/g, ' ')
+      // 1. Convert singular `\n` between content-characters to blanks (implicitely excludes the FOLD-exception `\n[space]`).
+      // any character except newline can be content to the left of \n, none-space is required afterwards
+      .replace(/(?<=[^\n])\n(?=\S)/g, ' ')
       // 2. Remove one `\n` which is followed by (at least one) empty line(s)
       .replace(/(?<!^)\n(\n+)(?![ \t])/g, '$1');
   }
 
-  #jsonMask(string, subs = YamlToken.JSON_MASKING){
+  #jsonMask(string, subs = YamlToken.JSON_MASKING) {
     let exp = r`/(${Object.keys(subs).join('|')})/g`
-    return string.replace(exp, (f)=>subs[f]) 
+    return string.replace(exp, (f) => subs[f])
   }
 
   /**
@@ -1007,40 +1041,20 @@ class YamlToken {
    * - `SQ` are literal strings, but the outer ' must be stripped, as these are **not** content.
    * - `NQ` might be JSON primitives (booleans, numbers, null).
    */
-  #postProcess(result){
+  #postProcess(result) {
     // blocks of any kind are strings, there is no clever evaluation of content or handling of quotes
-    if(this.#style != 'FLOW') { return result; }
+    if (this.#style != 'FLOW') { return result; }
     result = result.trim();
-    switch(this.#quoting){
+    switch (this.#quoting) {
       // If it has any whitespace, it's a string. If not, fallthrough as it might be another JSON primitive.
-      case 'NQ': if(/\s/.test(result)) { return result; }
+      case 'NQ': if (/\s/.test(result)) { return result; }
       // Double-quoted is parsed as JSON for backslash sequences, fallback to just unquoting on failure
-      case 'DQ': try{ return JSON.parse(this.#jsonMask(result)); } catch { /* ignore */ };
+      case 'DQ': try { return JSON.parse(this.#jsonMask(result)); } catch { /* ignore */ };
       // Single-quoted doesn't support escapes other than '' which is handled in `#prepareFlow()`, so just unquote
       case 'SQ': result = unquote(result, result.startsWith('"'));
     }
     return result;
   }
-}
-
-/**
- * Helper class that can be used to transport meta-information about the origin of a property.
- * Most use cases shouldn't care because of the valueOf implementation and just behave as if it was a string.
- * One notable exception is default initialisation by existence checks.
- */
-class PropValue {
-  constructor(val, source = CURRENT_FILE) {
-    this.value = val;
-    this.source = source;
-  }
-
-  toJSON() { return this.value }
-  valueOf() { return this.value }
-  toString() { return String(this.value) }
-}
-function handleValue(value) {
-  try { return new PropValue(JSON.parse(value)); } catch (e) { }
-  return new PropValue(unquote(value));
 }
 
 /** @endsection */

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/logger.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/logger.js
@@ -62,9 +62,9 @@ class Logger {
   /**
    * Change the default logging configuration for all module loggers that don't give more specific configuration during creation.
    * 
-   * @param {Level|string} maxLevel - max log level to write.
-   * @param {object|string} [channelTargets] - "default" to reset or a dict of {Level.Name: [channels...]}.
-   * @param {boolean} [merge=false] - for channelTargets={object}. Merge with current (true), Replace current (false).
+   * @arg {Level|string} maxLevel - max log level to write.
+   * @arg {object|string} [channelTargets] - "default" to reset or a dict of {Level.Name: [channels...]}.
+   * @arg {boolean} [merge=false] - for channelTargets={object}. Merge with current (true), Replace current (false).
    *
    * @see Logger.#writers for details on channels
    */
@@ -175,6 +175,22 @@ class Logger {
 
   trace(...data) { this.#mapToOutput(Level.TRACE, ...data); }
 
+  /** 
+   * Can be used in situations where code decides log level programmatically.  
+   * Most places should preferably use the specialized methods, however.
+   */
+  log(level, ...data) { this.#mapToOutput(Level[level], ...data); }
+
+  /** 
+   * Some log statements are expensive to calculate.  
+   * This method allows to only do this when given log level is enabled.
+   * @arg {Level|string} level
+   * @arg {function} provider should return a string or object to log
+   */
+  logWhen(level, provider){
+    if(Level[level] <= this.maxLevel) { this.log(level, provider()); }
+  }
+
   setCustomWriter(handler = null, channelName = "custom") {
     if (handler == null) {
       delete this.#writers[channelName];
@@ -252,7 +268,7 @@ module.exports = {
   /** Level for usage with static shorthand method 'write' */
   Level,
 
-  /** Shorthand convenience method to use were full Logger instance is not needed. */
+  /** Shorthand convenience method to use where full Logger instance is not needed. */
   write: Logger.write,
 
   /** 

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -58,15 +58,6 @@ class ParserTests {
       //console.error(JSON.stringify(old.features.sharedFeatures.feature[0], null, 2))
     }
   */
-  newYaml() {
-    let file = `${ROOT_PATH}/tmp/es_features.yml`;
-    let newStyle = parser.yamlToDict_IMPL(file);
-
-    //file = `${ROOT_PATH}/tmp/es_systems.yml`;
-    //newStyle = parser.yamlToDict_IMPL(file);
-    //console.error(JSON.stringify(newStyle, null, 2));
-    assert.fail()
-  }
 
   parseLineCommentedJsonString() {
     let source = `{
@@ -218,10 +209,9 @@ colonAsContent: :start :end
   }
 
   comments() {
-    // FIXME/TODO: YAML spec completely disallows comments within multiline blocks,
-    // the internal parser SKIPS them for now 
     let data =
       `
+%ignore directives
 commentFirst: #ignored
   value
 commentAfter: [true] #ignore
@@ -243,6 +233,189 @@ list: #  list header
       commentAfter: [true],
       'ml-string': 'content start content end',
       list: ['value', 'v2']
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  dictNesting_basic() {
+    let data = `
+topLevel:
+  middle:
+    last: true
+  oneUp:
+    deeper: string
+fullUp: 88`;
+
+    let expected = {
+      topLevel: {
+        middle: { last: true },
+        oneUp: { deeper: 'string' }
+      },
+      fullUp: 88
+
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  listNesting_basic() {
+    let data = `
+- A
+- B
+- no
+- yes`;
+
+    let expected = ['A', 'B', 'no', 'yes']
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  nesting_mixed() {
+    let data = `
+topLevel:
+  listSameIndent:
+  - entry 1
+  - subDict:
+      deeper: 42
+  listSibling: true
+  deeperList:
+    - 
+      key1: ofObjInList1  
+      key2: ofObjInList2
+    - false
+allClosed: true
+multiDimensional:
+- - A
+  - B
+- - 1
+  - 2`;
+
+    let expected = {
+      topLevel: {
+        listSameIndent: [
+          'entry 1',
+          { subDict: { deeper: 42 } }
+        ],
+        listSibling: true,
+        deeperList: [
+          {
+            key1: 'ofObjInList1',
+            key2: 'ofObjInList2',
+          },
+          false
+        ]
+      },
+      allClosed: true,
+      multiDimensional: [
+        ['A', 'B'],
+        [1, 2]
+      ]
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  flowStructure() {
+    let data = `
+dict: { one: 1, two: 2,
+  three: 3 }
+arr: 
+  [ 5, 6, 7, 8
+  ]
+d>a: {
+  subArr: [ true, false, true ]
+}
+a>d: [ {c: A}, {c: 0.2} ]
+`;
+
+    let expected = {
+      dict: { one: 1, two: 2, three: 3 },
+      arr: [5, 6, 7, 8],
+      'd>a': { subArr: [true, false, true] },
+      'a>d': [{ c: 'A' }, { c: 0.2 }]
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  flowStrings() {
+    let data = `
+mixedFlow: [
+  45.6,
+  broken down
+  multiline flow
+  string,
+  false
+  ]
+dq:
+     "  starts with 2 blanks, then\\
+            <previous (masked) should be IGNORED
+        <previous should be folded\\"
+        \\n<-valid LF escape"
+sq: ' start with BLNK ''<-masked
+    \\n<-escapes not evaluated'
+`;
+
+    let expected = {
+      mixedFlow: [45.6, 'broken down multiline flow string', false],
+      dq: '  starts with 2 blanks, then<previous (masked) should be IGNORED <previous should be folded" \n<-valid LF escape',
+      sq: " start with BLNK '<-masked \\n<-escapes not evaluated"
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  multilineStrings() {
+    let data = `
+mixedFlow: [
+  45.6,
+  broken down
+  multiline flow
+  string,
+  false
+  ]
+literalBlock: | # also tests default chomp mode 'clip'
+  line with 2 trailing spaces  
+
+  line after EMPTY line
+
+  
+  
+foldedBlock: >
+  1 trailing space 
+
+  <after EMPTY
+  <folded to space
+  
+strip: |-
+  don't keep trailing LF
+
+keep: |+
+  4 newlines
+  
+  
+  
+
+indent2: >2-
+    deeper text
+    in 2 lines
+  indicated level
+`
+    let expected = {
+      mixedFlow: [45.6, 'broken down multiline flow string', false],
+      literalBlock: 'line with 2 trailing spaces  \n\nline after EMPTY line\n',
+      foldedBlock: '1 trailing space \n<after EMPTY <folded to space\n',
+      strip: "don't keep trailing LF",
+      keep: '4 newlines\n\n\n\n',
+      //line breaks on transitions between indented/none-indented are kept
+      indent2: '  deeper text\n  in 2 lines\nindicated level'
     }
 
     let result = parser.yamlToDict_IMPL(data)

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -172,8 +172,8 @@ literal: |1
         { obj: { key: "value" } },
         { 'sub-sub-list': ["something"] }
       ],
-      literal: 
-`nesting start  
+      literal:
+        `nesting start  
 same
 
   deeper
@@ -184,7 +184,7 @@ back
 
     let result = parser.yamlToDict(sourceLines);
     assert.deepEqual(sanitizeDataObject(result), expected);
-    
+
     let newStyle = parser.yamlToDict_IMPL(sourceLines);
     assert.deepEqual(newStyle, result, "new parser sucks!")
 
@@ -192,4 +192,62 @@ back
   }
 }
 
-runTestClass(ParserTests)
+class YamlDetailTests {
+  simpleKVPs() {
+    let data =
+      `boolval  : false
+wordsAreTakenFull: truefalse
+forcedBoolString: "false"
+forcedNumString: '5.8'
+number: 4.6
+colonAsContent: :start :end
+'quoted : key': ...works
+`
+
+    let expected = {
+      boolval: false,
+      wordsAreTakenFull: 'truefalse',
+      forcedBoolString: 'false',
+      forcedNumString: '5.8',
+      number: 4.6,
+      colonAsContent: ':start :end',
+      'quoted : key': '...works'
+    }
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  comments() {
+    // FIXME/TODO: YAML spec completely disallows comments within multiline blocks,
+    // the internal parser SKIPS them for now 
+    let data =
+      `
+commentFirst: #ignored
+  value
+commentAfter: [true] #ignore
+#nothing happens
+ml-string: 
+  #ignored
+  content start
+  #part of content
+  content end
+list: #  list header
+  #first entry
+  - value
+  #second entry
+  - v2
+`
+
+    let expected = {
+      commentFirst: 'value',
+      commentAfter: [true],
+      'ml-string': 'content start content end',
+      list: ['value', 'v2']
+    }
+
+    let result = parser.yamlToDict_IMPL(data)
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+}
+
+runTestClasses(ParserTests, YamlDetailTests)

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -176,9 +176,6 @@ back
     let result = parser.yamlToDict(sourceLines);
     assert.deepEqual(sanitizeDataObject(result), expected);
 
-    let newStyle = parser.yamlToDict_IMPL(sourceLines);
-    assert.deepEqual(newStyle, result, "new parser sucks!")
-
     assertParsedFromFile('propertyTest.yml', sourceLines, expected);
   }
 }
@@ -204,7 +201,7 @@ colonAsContent: :start :end
       colonAsContent: ':start :end',
       'quoted : key': '...works'
     }
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -235,7 +232,7 @@ list: #  list header
       list: ['value', 'v2']
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -257,7 +254,7 @@ fullUp: 88`;
 
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -270,7 +267,7 @@ fullUp: 88`;
 
     let expected = ['A', 'B', 'no', 'yes']
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -316,7 +313,7 @@ multiDimensional:
       ]
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -340,7 +337,7 @@ a>d: [ {c: A}, {c: 0.2} ]
       'a>d': [{ c: 'A' }, { c: 0.2 }]
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -368,7 +365,7 @@ sq: ' start with BLNK ''<-masked
       sq: " start with BLNK '<-masked \\n<-escapes not evaluated"
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 
@@ -418,7 +415,7 @@ indent2: >2-
       indent2: '  deeper text\n  in 2 lines\nindicated level'
     }
 
-    let result = parser.yamlToDict_IMPL(data)
+    let result = parser.yamlToDict(data)
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
 }

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -243,15 +243,17 @@ topLevel:
     last: true
   oneUp:
     deeper: string
-fullUp: 88`;
+fullUp: 88
+emptyKey:
+`;
 
     let expected = {
       topLevel: {
         middle: { last: true },
         oneUp: { deeper: 'string' }
       },
-      fullUp: 88
-
+      fullUp: 88,
+      emptyKey: null
     }
 
     let result = parser.yamlToDict(data)
@@ -328,13 +330,17 @@ d>a: {
   subArr: [ true, false, true ]
 }
 a>d: [ {c: A}, {c: 0.2} ]
+emptyDict: {}
+emptyArr: []
 `;
 
     let expected = {
       dict: { one: 1, two: 2, three: 3 },
       arr: [5, 6, 7, 8],
       'd>a': { subArr: [true, false, true] },
-      'a>d': [{ c: 'A' }, { c: 0.2 }]
+      'a>d': [{ c: 'A' }, { c: 0.2 }],
+      emptyDict: {},
+      emptyArr: []
     }
 
     let result = parser.yamlToDict(data)

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -130,6 +130,14 @@ sublist-with-same-level-nest:
     key: value
 - sub-sub-list:
   - something
+
+literal: |1
+ nesting start  
+ same
+ 
+   deeper
+
+ back
 `;
     let expected = {
       root: {
@@ -163,14 +171,22 @@ sublist-with-same-level-nest:
         "E1",
         { obj: { key: "value" } },
         { 'sub-sub-list': ["something"] }
-      ]
+      ],
+      literal: 
+`nesting start  
+same
+
+  deeper
+
+back
+`
     };
 
     let result = parser.yamlToDict(sourceLines);
     assert.deepEqual(sanitizeDataObject(result), expected);
     
     let newStyle = parser.yamlToDict_IMPL(sourceLines);
-    assert.deepEqual(newStyle, expected, "new parser sucks!")
+    assert.deepEqual(newStyle, result, "new parser sucks!")
 
     assertParsedFromFile('propertyTest.yml', sourceLines, expected);
   }

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -45,6 +45,28 @@ class ParserTests {
     result = parser.confToDict(source);
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
+  /*
+    compareXml() {
+      let file = `${ROOT_PATH}/tmp/FS_ROOT/opt/batocera-emulationstation/bin/es_features.cfg`;
+      let old = parser.xmlToDict(file);
+      let newStyle = parser.xmlNew(file);
+  
+      assert.deepEqual(
+        sanitizeDataObject(old.features),
+        sanitizeDataObject(newStyle.features)
+      );
+      //console.error(JSON.stringify(old.features.sharedFeatures.feature[0], null, 2))
+    }
+  */
+  newYaml() {
+    let file = `${ROOT_PATH}/tmp/es_features.yml`;
+    let newStyle = parser.yamlToDict_IMPL(file);
+
+    //file = `${ROOT_PATH}/tmp/es_systems.yml`;
+    //newStyle = parser.yamlToDict_IMPL(file);
+    //console.error(JSON.stringify(newStyle, null, 2));
+    assert.fail()
+  }
 
   parseLineCommentedJsonString() {
     let source = `{
@@ -67,27 +89,48 @@ class ParserTests {
   }
 
   parseYaml() {
-    let sourceLines = [
-      "root:",
-      "  subPropertyValue: true",
-      "  subDict:",
-      "    deeper: [9, 8, 7]",
-      "    inlineDict: { aKey: [arr] }",
-      "  up_again:  # inline comment",
-      "    - A",
-      "    - B",
-      "# commented line",
-      "colonTest: some:thing",
-      "another-root:",
-      "  down: 2.5",
-      "  object_list:",
-      "    -",
-      "      key: some_str",
-      "      value: 609",
-      "aspect-ratios:",
-      "  '4:3' : '16:9'",
-      '  "16:9"      : "32:18"'
-    ];
+    let sourceLines = `
+root:
+  subPropertyValue: true
+  subDict:
+    deeper: [9, 8, 7]
+    inlineDict: { aKey: [arr] }
+  up_again:  # inline comment
+    - A
+    - B
+ml-mixed-flow: [
+    45.6,
+    { option: value, nodes: [
+      3, 4, 5, 6,
+      broken down
+      multiline flow
+      string,
+      false
+    ]}
+  ]
+# commented line
+colonTest: some:thing
+another-root:
+  down: 2.5
+  object_list:
+    -
+      key: some_str
+      value: 609
+aspect-ratios:
+  '4:3' : '16:9'
+  "16:9"      : "32:18"
+ml-string:
+  ABC
+  123
+  all LF folded
+
+sublist-with-same-level-nest:
+- E1
+- obj:
+    key: value
+- sub-sub-list:
+  - something
+`;
     let expected = {
       root: {
         subPropertyValue: true,
@@ -99,6 +142,13 @@ class ParserTests {
         },
         up_again: ['A', 'B']
       },
+      'ml-mixed-flow': [
+        45.6,
+        {
+          option: "value",
+          nodes: [3, 4, 5, 6, "broken down multiline flow string", false]
+        }
+      ],
       colonTest: 'some:thing',
       'another-root': {
         down: 2.5,
@@ -107,13 +157,22 @@ class ParserTests {
       'aspect-ratios': {
         '4:3': '16:9',
         '16:9': '32:18'
-      }
+      },
+      'ml-string': "ABC 123 all LF folded",
+      'sublist-with-same-level-nest': [
+        "E1",
+        { obj: { key: "value" } },
+        { 'sub-sub-list': ["something"] }
+      ]
     };
 
-    let result = parser.yamlToDict(sourceLines.join("\n"));
+    let result = parser.yamlToDict(sourceLines);
     assert.deepEqual(sanitizeDataObject(result), expected);
+    
+    let newStyle = parser.yamlToDict_IMPL(sourceLines);
+    assert.deepEqual(newStyle, expected, "new parser sucks!")
 
-    assertParsedFromFile('propertyTest.yml', sourceLines.join("\n"), expected);
+    assertParsedFromFile('propertyTest.yml', sourceLines, expected);
   }
 }
 


### PR DESCRIPTION
Exchange external calls to `yq` with a custom internal yaml parser implementation.

Reasons:
1. It is much faster than external calls
2. `yq` can be dropped from the dependencies and github workers (once `xq` is gone) -> cheaper and faster test setup
3. No NPM dependencies
4. Result equality with `pyyaml` (used by batocera toolchain) can be implemented where required. This is important because all parser libraries greatly vary in feature support for the yaml spec and this project tries to keep as API compatible to batocera as possible. So config files should also result in the same values (mostly an issue with multiline strings).

This PR also prepares a few generic utilities for an internal xml parsing implementation that behaves like `xmlTodict`, so that `xq` can also be dropped.

This PR still contains a few snippets of low-quality test code for XML parsing. Will be removed with the next step.