### PR TITLE
Rework parsing of `YAML` and `XML` 2/2

### DIFF
--- a/.github/workflows/build_config_branch.yml
+++ b/.github/workflows/build_config_branch.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - run: echo TBD
       #- name: checkout
-      #  uses: actions/checkout@v4
+      #  uses: actions/checkout@v5
       #  with:
       #    ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/scripts/yq
+++ b/.github/workflows/scripts/yq
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# this file serves as an adapter from archlinux yq to the one used in ubuntu
-
-python -m yq "$@"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/update_pages.yml
+++ b/.github/workflows/update_pages.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -18,7 +18,7 @@ depends=(
   'sdl2_mixer' 'sdl2' 'libpulse'
   'rapidjson' 'boost' 'libvlc' 'freeimage' 'freetype2' 'pugixml'
   #PKGBUILD and emulator configuration
-  'nodejs' 'yq'
+  'nodejs'
 )
 
 # these are added to 'depends' in package()

--- a/scripts/generate-config.sh
+++ b/scripts/generate-config.sh
@@ -43,11 +43,6 @@ startdir="$ROOT_DIR"
     sudo ln -s "$(which node)" /usr/bin/node
   fi
 
-  if ! python -c "import yq" 2>/dev/null; then
-    echo "install missing dependency python yq/xq"
-    sudo python -m pip install yq
-  fi
-
   cd "$ROOT_DIR"
   
   configArgs=()

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/io/parsers.js
@@ -14,12 +14,6 @@
  * - *.cfg files
  * - *.json
  * - *.xml
- * 
- * For XML and YAML formatted files, an external tool will be used (xq and yq) to transform to json first. 
- * This makes those types effectively twice as expensive to process.  
- * Thus, where speed matters, the user should not use yml. Moreover, frequently parsed files should be handled with 
- * dedicated in-process parsing functions.  
- * Example: `es_settings.cfg` is an xml file, but very simply structured.
  */
 const log = require('logger').get()
 const data = require('utils/data');
@@ -37,8 +31,8 @@ const PARSE_FUNCTIONS = Object.freeze({
   'conf': confToDict,
   'json': jsonToDict,
   'cfg': esSettingsToDict,
-  'xml': xmlNew,
-  'amgp': xmlNew
+  'xml': xmlToDict,
+  'amgp': xmlToDict
 });
 
 const CONTENT_PROVIDER = Object.freeze({
@@ -48,16 +42,6 @@ const CONTENT_PROVIDER = Object.freeze({
       : filename;
     if (split) { result = result.split('\n') }
     return result;
-  },
-  YQ: (filename, split = true) => {
-    return existsSync(filename)
-      ? execSync(`yq . "${filename}"`, { encoding: 'utf8' })
-      : execSync('yq', { encoding: 'utf8', input: filename });
-  },
-  XQ: (filename, split = true) => {
-    return existsSync(filename)
-      ? execSync(`xq . "${filename}"`, { encoding: 'utf8' })
-      : execSync('xq', { encoding: 'utf8', input: filename });
   }
 });
 
@@ -127,40 +111,6 @@ function confToDict(confFile) {
   })
 }
 
-const XML = {
-  ENCODED_CHARS_REGEX: /&lt;|&gt;|&amp;|&apos;|&quot;/g,
-  removeComments(lines) {
-    if (Array.isArray(lines)) { lines = lines.join('\n') }
-
-    while (lines.includes('<!--')) {
-      let startIndex = lines.indexOf('<!--');
-      let endIndex = lines.indexOf('-->', startIndex);
-      lines = lines.substring(0, startIndex) + lines.substring(endIndex + 3);
-    }
-    return lines.split('\n');
-  },
-
-  condenseWhitespace(value) {
-    return value.replace(/\s*$\s*/gm, ' ').trim();
-  },
-
-  decodeValue(value) {
-    return value.replace(XML.ENCODED_CHARS_REGEX, match => {
-      switch (match) {
-        case '&lt;': return '<'
-        case '&gt;': return '>'
-        case '&amp;': return '&'
-        case '&apos;': return "'"
-        case '&quot;': return '"'
-      }
-    });
-  },
-
-  decodeAttribute(value) {
-    return XML.decodeValue(XML.condenseWhitespace(value));
-  },
-}
-
 const CFG_PROP_LINE = /<(\w+) name="(.*)" value="(.*)"\s*\/>/
 const SETTINGS_TYPES = {
   string: String,
@@ -169,8 +119,8 @@ const SETTINGS_TYPES = {
   bool: Boolean
 }
 function esSettingsToDict(cfgFile) {
-  return readTextPropertyFile(cfgFile, (lines) => {
-    lines = XML.removeComments(lines);
+  return readTextPropertyFile(cfgFile, (source) => {
+    lines = XML.removeComments(source).split('\n');
     let result = {};
     lines.map(_ => CFG_PROP_LINE.exec(_)).filter(_ => _ != null).forEach(line => {
       let key = XML.decodeValue(line[2]);
@@ -179,7 +129,7 @@ function esSettingsToDict(cfgFile) {
       details.effectiveKey.set(result, SETTINGS_TYPES[line[1]](details.value.valueOf()));
     });
     return result;
-  });
+  }, CONTENT_PROVIDER.DIRECT, false);
 }
 
 function jsonToDict(jsonFile, contentProvider = CONTENT_PROVIDER.DIRECT) {
@@ -205,46 +155,8 @@ function jsonToDict(jsonFile, contentProvider = CONTENT_PROVIDER.DIRECT) {
 }
 
 function xmlToDict(xmlFile) {
-  let result = jsonToDict(xmlFile, CONTENT_PROVIDER.XQ);
-  return typeof result['NO-ROOT'] != "undefined"
-    ? result['NO-ROOT']
-    : result;
-}
-
-function xmlNew(xmlFile) {
-  let result = readTextPropertyFile(xmlFile, sourceText => {
-
-    let context = new ParseContext();
-    context.addAttributeNode = function(m) {
-      this.enterNode(`@${m[1]}`, m[1] + '=');
-      this.addContent(handleValue(XML.decodeAttribute(m[2].slice(1, -1))), m[2])
-      this.leaveNode();
-    }.bind(context);
-
-    let R = new RegexDocParser({
-      // none-node whitespace
-      BLK: [/\s+/ms, m => context.current.addRaw(m[0])],
-      // start of node
-      SON: [/<(?!\/)([\p{L}\._\d-]+?)([\s>]|(?=\/))/su, m => context.enterNode(m[1], m[0])],
-      //attribute
-      NATTR: [/(\w+)=("[^"]*"|'[^']*')/s, context.addAttributeNode],
-      // end of node opening tag
-      EOH: [/\s*\>/ms, m => context.nodeHeaderDone(m[0])],
-      // node value/content
-      VAL: [/(\S[^\<\>]*?)\s*(?=\<)/ms, m => context.addContent(handleValue(XML.decodeValue(m[1])), m[0])],
-      // end of the node (closing tag)
-      EON: [/<?\/[\p{L}\._\d-]*?>/msu, m => context.leaveNode(m[0])],
-    }, 'XML');
-
-    sourceText = sourceText
-      .replace(/\<\?.*?\?\>/gs, '')
-      .replace(/\<!--.*?--\>/gs, '');
-
-    context.start(R);
-    R.exec(sourceText);
-
-    return context.current.valueOf();
-  }, CONTENT_PROVIDER.DIRECT, false);
+  let result = readTextPropertyFile(xmlFile, XML.parse, CONTENT_PROVIDER.DIRECT, false);
+  // 'NO-ROOT' is used internally as a pseudo root node for invalid fragments to create valid XML documents 
   return typeof result['NO-ROOT'] != "undefined"
     ? result['NO-ROOT']
     : result;
@@ -252,7 +164,6 @@ function xmlNew(xmlFile) {
 
 function yamlToDict(yamlFile) {
   return readTextPropertyFile(yamlFile, YAML.parse, CONTENT_PROVIDER.DIRECT, false);
-  //return jsonToDict(yamlFile, CONTENT_PROVIDER.YQ);
 }
 
 const FOLDER_SPEC = /^\w+(\.folder\[(".*?")\/?\]).*=.*/;
@@ -595,8 +506,8 @@ class UniversalNode {
       case 'ARRAY': return this.#content.map(UniversalNode.realValue);
       case 'TEXT': return this.#content.join('').trim();
     }
-    if (this.isMixed()) { return this.#rawValues.slice(...this.#rawContentIndices).join('').trim(); }
-    else if (this.#content.length == 1) { return UniversalNode.realValue(this.#content[0]); }
+    if (this.#content.length == 1) { return UniversalNode.realValue(this.#content[0]); }
+    else if (this.isMixed()) { return this.#rawValues.slice(...this.#rawContentIndices).join('').trim(); }
     else { return this.#content.join('').trim(); }
   }
 
@@ -702,7 +613,70 @@ class PropValue {
 /** @endsection */
 
 /**
- *  @section YAML-specific code
+ * @section Generic xml2dict parser
+ */
+
+class XML extends ParseContext {
+  static ENCODED_CHARS_REGEX = /&lt;|&gt;|&amp;|&apos;|&quot;/g;
+
+  static decodeValue(value){
+    return value.replace(XML.ENCODED_CHARS_REGEX, match => {
+      switch (match) {
+        case '&lt;': return '<'
+        case '&gt;': return '>'
+        case '&amp;': return '&'
+        case '&apos;': return "'"
+        case '&quot;': return '"'
+      }
+    });
+  }
+
+  static removeComments(source){ return (source || "").replace(/\<!--.*?--\>/gs, ''); }
+
+  static parse(sourceText){
+    let xml = new XML();
+    xml.bindFunctions();
+
+    let R = new RegexDocParser({
+      // none-node whitespace
+      BLK: [/\s+/ms, m => xml.current.addRaw(m[0])],
+      // start of node
+      SON: [/<(?!\/)([\p{L}\._\d-]+?)([\s>]|(?=\/))/su, m => xml.enterNode(m[1], m[0])],
+      //attribute
+      NATTR: [/(\w+)=("[^"]*"|'[^']*')/s, xml.addAttributeNode],
+      // end of node opening tag
+      EOH: [/\s*\>/ms, m => xml.nodeHeaderDone(m[0])],
+      // node value/content
+      VAL: [/(\S[^\<\>]*?)\s*(?=\<)/ms, xml.addValueNode],
+      // end of the node (closing tag)
+      EON: [/<?\/[\p{L}\._\d-]*?>/msu, m => xml.leaveNode(m[0])],
+    }, 'XML');
+
+    sourceText = XML.removeComments(sourceText.replace(/\<\?.*?\?\>/gs, ''));
+    xml.start(R);
+    R.exec(sourceText);
+
+    return xml.root.valueOf();
+  }
+
+  addAttributeNode(m) {
+    this.enterNode(`@${m[1]}`, m[1] + '=');
+    let cleanedValue = m[2].slice(1, -1).replace(/\s*$\s*/gm, ' ').trim();
+    this.addContent(handleValue(XML.decodeValue(cleanedValue)), m[2]);
+    this.leaveNode();
+  }
+
+  addValueNode(m){
+    let value = m[1];
+    let raw = m[0];
+    this.addContent(handleValue(XML.decodeValue(value)), raw);
+  }
+}
+
+/** @endsection */
+
+/**
+ * @section YAML-specific code
  */
 
 /**
@@ -824,6 +798,7 @@ class YAML extends ParseContext {
         break;
     }
   }
+
   consumeToken() {
     if (!this.hasToken()) { return; }
 
@@ -1153,7 +1128,7 @@ module.exports = {
   parseDict, analyseProperty,
   SOURCE_FILE,
   // expose the parse functions themselves for places where the type is know, but not matching the extension
-  confToDict, xmlToDict, xmlNew, yamlToDict, jsonToDict, esSettingsToDict,
+  confToDict, xmlToDict, yamlToDict, jsonToDict, esSettingsToDict,
   //for information/API puposes
   FORMATS,
   XML,

--- a/sources/fs-root/opt/batocera-emulationstation/node_modules/utils/path.js
+++ b/sources/fs-root/opt/batocera-emulationstation/node_modules/utils/path.js
@@ -104,7 +104,7 @@ function readSystemRomPaths(...fileGlobs) {
   let { execSync } = require('node:child_process');
   let { XML } = require('io/parsers');
   let sourceLoader = `shopt -s nullglob; /bin/cat ${fileGlobs.join(' ')}`;
-  let fullSource = XML.removeComments(execSync(sourceLoader, { encoding: 'utf8', shell: '/bin/bash' })).join('\n');
+  let fullSource = XML.removeComments(execSync(sourceLoader, { encoding: 'utf8', shell: '/bin/bash' }));
   if (data.isEmpty(fullSource)) throw new Error(`No es_systems found with glob(s) [${fileGlobs.join(' ')}]`);
   let systems = execSync(`${SYSTEMS_GREP}`, { encoding: 'utf8', input: fullSource }).split('<system>');
 

--- a/test/js/libs/parsing.test.js
+++ b/test/js/libs/parsing.test.js
@@ -45,19 +45,6 @@ class ParserTests {
     result = parser.confToDict(source);
     assert.deepEqual(sanitizeDataObject(result), expected);
   }
-  /*
-    compareXml() {
-      let file = `${ROOT_PATH}/tmp/FS_ROOT/opt/batocera-emulationstation/bin/es_features.cfg`;
-      let old = parser.xmlToDict(file);
-      let newStyle = parser.xmlNew(file);
-  
-      assert.deepEqual(
-        sanitizeDataObject(old.features),
-        sanitizeDataObject(newStyle.features)
-      );
-      //console.error(JSON.stringify(old.features.sharedFeatures.feature[0], null, 2))
-    }
-  */
 
   parseLineCommentedJsonString() {
     let source = `{
@@ -177,6 +164,72 @@ back
     assert.deepEqual(sanitizeDataObject(result), expected);
 
     assertParsedFromFile('propertyTest.yml', sourceLines, expected);
+  }
+}
+
+/** Difference to 'classic' xml2Dict: automatic type parsing of values with Json grammar. */
+class XmlDetailTests {
+  simpleList() {
+    let code = `<root>
+    <entry>12</entry>
+    <entry>String</entry>
+    <entry>false</entry>
+    <entry>{"obj": false}</entry>
+</root>`;
+
+    let expected = {
+      root: {
+        entry: [12, "String", false, { obj: false }]
+      }
+    }
+
+    let result = parser.xmlToDict(code);
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+  mixedElementList() {
+    let code = `<root>
+    <entry name="A">12</entry>
+    <entry name="B">String</entry>
+    <entry name="C">false</entry>
+    <entry name="D">{"obj": false}</entry>
+</root>`;
+
+    let expected = {
+      root: {
+        entry: [
+          { '@name': 'A', '#text': 12 },
+          { '@name': 'B', '#text': 'String' },
+          { '@name': 'C', '#text': false },
+          { '@name': 'D', '#text': { obj: false } },
+        ]
+      }
+    }
+
+    let result = parser.xmlToDict(code);
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  /** Contrary to regular XML parsing, xml2Dict trims away a lot more whitespaces. */
+  whitespaceHandling() {
+    let code = `
+    <root>    <subnode>    44\t   42   </subnode>\n\t<node-two>false</node-two>`;
+
+    let expected = { root: { subnode: '44\t   42', 'node-two': false } }
+
+    let result = parser.xmlToDict(code);
+    assert.deepEqual(sanitizeDataObject(result), expected);
+  }
+
+  /** Note: In theory, this is not a fully valid XML document. Just a fragment. */
+  documentWithoutRoot() {
+    let code = `
+<root>ABC</root>
+<root>123</root>`;
+
+    let expected = { root: ['ABC', 123] }
+
+    let result = parser.xmlToDict(code);
+    assert.deepEqual(sanitizeDataObject(result), expected);
   }
 }
 
@@ -426,4 +479,4 @@ indent2: >2-
   }
 }
 
-runTestClasses(ParserTests, YamlDetailTests)
+runTestClasses(ParserTests, XmlDetailTests, YamlDetailTests);


### PR DESCRIPTION
1. No more external `yq` in use.
2. Added some more tests.