### PR TITLE
Feature: Introduce API and Library to build forms

### DIFF
--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
@@ -123,7 +123,36 @@ function ui#requestInputImpl
 # @see [ui#runFormImpl](./backend-api.shl.md#uirunFormImpl)
 function ui#runFormImpl
 {
-  _printException "Forms are not supported on GUI" && exit 1
+  local __rawResult
+  local -a __resultLines
+  local __dialogStatus=1
+  while [ "$__dialogStatus" != 0 ]; do
+    __rawResult=$(
+      "ui#baseDialog" --form --title="$1" \
+        --separator=$'\n' --num-output --item-separator="|" \
+        "${__FORM_ARGS[@]}" "${__FORM_DATA[@]}"
+    )
+    #shellcheck disable=2181 # not possible here for readability reasons
+    if [ "$?" -gt 0 ]; then
+      #dialog got canceled
+      return 1
+    fi
+    readarray -t __resultLines <<< "$__rawResult"
+    "ui#verifyFormVars" LOOP
+    __dialogStatus="$?"
+  done
+  # apply transformations, if any
+  "ui#verifyFormVars" RESULT __FORM_DATA
+
+  # write the 'real' lines into the result assoc
+  local idx
+  for idx in "${!__resultLines[@]}"; do
+    varName="${__CONFIRM_PARAMETERS[$idx]}"
+    [ "$varName" != "__skip__" ] || continue
+
+    __form_result["$varName"]="${__FORM_DATA[$idx]}"
+  done
+  export -n -f "ui#baseDialog" "ui#requestFileImpl"
 }
 
 # @description GUI-style implementation of adding fields to a form. The underlying implementation uses `yad`.

--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
@@ -126,9 +126,168 @@ function ui#runFormImpl
   _printException "Forms are not supported on GUI" && exit 1
 }
 
+# @description GUI-style implementation of adding fields to a form. The underlying implementation uses `yad`.
+# 
+# `yad` is very sensitive to missing fields or 'initial data' values for fields.
+# 
+# This function makes sure the argument line remains consistent, regardless of field type. It also maintain meta
+# information about the form contents/variable names. This meta information is needed at the end when the user
+# clicks on OK/Confirm.
+#
+# **Full explanation**  
+# 'Initial data' arguments represent button actions, combo value lists, the checked state of checkboxes etc, 
+# However, they are **not** the text/label used as 'explanation'. These are part of an 'option'. Example:
+#  
+# ```bash
+# yad --form --field="Some detail":LBL --field="Confirm":CHK true
+# ```
+#
+# One might expect that this yields a dialog with a label and a pre-checked checkbox. This is not what happens.  
+# Labels do not use initial data, but the argument processing still requires it. 
+# The label is the first field and does not have initial data following its `--field` argument,
+# so it takes the initial data given with index 0, which is 'true'. 
+# The checkbox would have to take data index 1, but that does not exist, thus it remains unchecked. 
+# Working variants of the example above:
+#  
+#```bash
+# # interleaving initial data and fields
+# yad --form --field="Some detail":LBL '' --field="Confirm":CHK true
+#
+# #initial data at the end
+# yad --form --field="Some detail":LBL --field="Confirm":CHK '' true
+#```
+#
+# @see [ui#formAddField](./backend-api.shl.md#uiformAddField)
 function ui#formAddField
 {
-  _printException "Forms are not supported on GUI" && exit 1
+  local fieldType="$1"
+  local varName="$2"
+  local message="$3"
+  local iniData=${4:-''}
+  shift 4
+
+  # Skip creation of long label. Needed to prevent recursion between 'ui#formAddField' and 'ui#formLabel'.
+  # Also doesn't make sense for all types
+  local __skipLongLabel=""
+  case "$fieldType" in
+    BTN|FBTN) ;&
+    LBL|LINK) ;&
+    FL) # FileList will be treated specially below
+      __skipLongLabel=true
+  esac
+  [ -n "$__skipLongLabel" ] || "ui#formLabel" message
+
+  # yad allows an 'empty' type for plain text inputs which leads to confusing usages of the API
+  # the 'ui#formAddField' API specifies 'INPUT' for plain one-line texts - map this internally
+  if [ "$fieldType" = "INPUT" ]; then fieldType=""; fi
+
+  # `--file-filter` arguments passed to yad are shared between all file selection dialogs.
+  # That means it is not possible to force a single filter for one form field when there are multiple - the user will always be able to chose.
+  # As this is not desired, a custom file chooser is used, built from a button and a RO field.
+  # The button opens a regular customized file chooser and updates the RO with its output.
+  if [ "$fieldType" = "FL" ]; then
+    # we need a bit of index math to get the right numbers
+    local idx=${#__FORM_ARGS[@]}
+    (( idx+=2 )) # btn is +1, RO field will be +2
+    # shellcheck disable=2124 # array is mapped to string on purpose
+    local __btnCmd="${idx}:\$(ui#requestFileImpl \"${message}\" \"${iniData}\" ${@})"
+    __btnCmd="@bash -c 'echo \"${__btnCmd}\"'"
+    # temporarily export this function, must be 'unexported' when the dialog closes to not leak interna
+    export -f "ui#baseDialog" "ui#requestFileImpl"
+
+    "ui#formAddField" FBTN __skip__ "$message" "$__btnCmd"
+    message="∟"
+    fieldType="RO"
+  fi
+
+  __FORM_ARGS+=("--field=${message}:${fieldType:- }")
+  __FORM_DATA+=("${iniData}")
+  __CONFIRM_PARAMETERS+=("${varName}")
+}
+
+# @endsection
+
+# -----------
+# @section Implementation-specific helper functions
+
+# @description
+# In form dialogs, question labels are normally placed in front of the inputs, in a tabular manner.
+# Sentences which are too long make the dialog look strange. To prevent this, the text must be moved
+# into a dedicated read-only label above the actual text.
+# This is what this function does: Any sentence longer than 3 words is declared as label instead.
+# This function is meant to be called within the context of a running `form`.
+# First argument must be the name of the variable containing the sentence to check.
+# The variable's content will be modified accordingly.
+function ui#formLabel 
+{
+  local -n __label="$1"
+  __label=$(lc "$__label")
+  local __words=()
+  _explode __words "$__label"
+  if [ "${#__words[@]}" -gt 3 ]; then
+    "ui#formAddField" LBL __skip__ "$__label"
+    __label=""
+  fi
+}
+
+# @description
+# To be used from within 'ui#runFormImpl'. Goes over arrays and verifies content of __resultLines.
+# Behaviour of verifier functions can potentially be different in LOOP and RESULT modes:
+# - stdout in LOOP mode shall be used to change initial value when re-opening the form
+# - In RESULT mode, if required, a mapping of the form-internal keys to the expected output is to be done.  
+#   This is mostly the case for choice questions which get indices as raw values, but should return 'key' strings.
+#
+# When given `$2`, the output of verifiers is written at the array index corresponding to input.  
+# For correct mapping of values to verifiers, a correctly populated array __CONFIRM_PARAMETERS is required.
+# It must be of the same length as `__resultLines` and map indices to var names, or use `__skip__` for lines to ignore.
+#
+# @arg $1 mode-string LOOP/RESULT
+# @arg $2 arr-name result array name 
+function ui#verifyFormVars
+{
+  if [ -v "$2" ]; then
+    local -n resultArr="$2"
+  else
+    local -a resultArr
+  fi
+  local verifier varName adjustedValue
+  local numErrors=0
+  local idx
+  for idx in "${!__resultLines[@]}"; do
+    varName="${__CONFIRM_PARAMETERS[$idx]}"
+    [ "$varName" != "__skip__" ] || continue
+
+    verifier=()
+    _explode verifier "${__VERIFIERS[$varName]:-"ui#verifyPassActual"}"
+    if ! adjustedValue=$(VMODE="$1" "${verifier[@]}" "${__resultLines[$idx]}" "${__FORM_DATA[$idx]}"); then
+      (( ++numErrors ))
+    fi
+
+    # shellcheck disable=2034 # either reference to outside, or local to swallow values (unused on purpose)
+    resultArr[idx]="$adjustedValue"
+  done
+  return "$numErrors"
+}
+
+# @description
+# Implementation of a verifier for choice-questions in forms.
+# @arg $1 name of array containing original choice keys (provided by ui:askChoice)
+# @arg $2 (changed) value of the current loop iteration/retry
+function ui#verifyChoice 
+{
+  local -n arr="$1"
+  if [ "$VMODE" = "LOOP" ]; then
+    # For now: Just re-build the choice list.
+    # Later on: translate $2 into `^` at the right place to keep pre-selected value on restart
+    _join \| "${arr[@]}"
+  elif [ "$VMODE" = "RESULT" ]; then
+    echo -n "${arr[$2]}" 
+  fi
+}
+
+function ui#verifyPassActual
+{
+  printf '%s' "$1"
 }
 
 # @endsection

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
@@ -57,6 +57,11 @@ function ui:requestConfirmation {
   if [ "$#" -gt 0 ]; then shift; fi
   _message=$(lc "$_message" "$@")
 
+  if "ui#isTX"; then
+    "ui#formAddField" CHK "${use_var:?need var name for form}" "$_message" false
+    return 0
+  fi
+
   if "ui#requestConfirmationImpl" "$_message"; then 
     "ui#resultOut" "true" && return 0
   else
@@ -74,6 +79,12 @@ function ui:ask {
   local _default="$2"
 
   local _question=$(lc "%%msg%% (default: '%%_default%%')" msg _default)
+
+  if "ui#isTX"; then
+    "ui#formAddField" "" "${use_var:?required in TX mode}" "$_question" "$_default"
+    return 0
+  fi
+
   if ! "ui#asReply" ui#requestInputImpl "$_question" "${__default}"; then
     [ "$1" = "--optional" ] || ui errorAbort 'An answer is required for this question.'
   fi
@@ -107,14 +118,22 @@ function ui:askChoice {
   local __optional=""
   if [ "$1" = "--optional" ] || "ui#isTX"; then # FIXME: non-optional values don't work in TX mode yet
     __optional=true
-    shift
+    shift || true
     local __cancelMessage=$(lc "None of the given options")
   else
     local __cancelMessage=$(lc "None - Cancel and quit")
   fi
   [ "$1" = "--choices" ] && shift || true
 
-  local __choices=('')
+  if "ui#isTX"; then
+    # the array must be accessible from outside sub-processes in TX mode
+    # so that verification and value reading works
+    local -n __choices="${use_var:?need a variable name in TX mode}"
+  else
+    local __choices
+  fi
+
+  __choices=('')
   local -a __textOverrides
 
   local index 
@@ -128,6 +147,12 @@ $([ -t 0 ] || head -n 20)
 $(printf '%s\n' "$@")
 ABORT::${__cancelMessage}
 EOF
+
+  if "ui#isTX"; then
+    "ui#formAddField" CB "$use_var" "$__userMessage" "$(_join \| "${__textOverrides[@]}")"
+    __VERIFIERS["$use_var"]="ui#verifyChoice $use_var"
+    return 0
+  fi
 
   if ! "ui#asReply" "ui#requestChoiceImpl" "$__userMessage" __textOverrides 1; then
     REPLY="${#__choices[@]}"
@@ -164,6 +189,11 @@ function ui:askDirectory {
     shift 2
   fi
 
+  if "ui#isTX"; then
+    "ui#formAddField" DIR "${use_var:?required in TX mode}" "$__userMessage" "${__default:-"$HOME"}"
+    return 0
+  fi
+
   if ! "ui#asReply" ui#requestDirectoryImpl "$__userMessage" "${__default:-"$HOME"}"; then
     # TODO: it might be better to pass that check into the impl to include in repeat loop?
     [ "$1" = "--optional" ] || ui errorAbort 'Directory is required'
@@ -198,6 +228,11 @@ function ui:askFile {
     while ! [[ "$1" =~ ^-- ]] && [ "$#" -gt 0 ]; do
       __types+=("$1") && shift
     done
+  fi
+
+  if "ui#isTX"; then
+    "ui#formAddField" FL "${use_var:?required in TX mode}" "$__userMessage" "${__default:-"$HOME"}" "${__types[@]}"
+    return 0
   fi
 
   if ! "ui#asReply" ui#requestFileImpl "$__userMessage" "${__default:-"$HOME"}" "${__types[@]:-'*'}"; then

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
@@ -300,7 +300,69 @@ function ui:errorAbort {
 # @arg $1 string (optional) short header message
 # @arg $2 -$n (optional) replacement strings for `lc`
 function ui:form {
-  echo TBD
+  local msg=$(lc "$@")
+  msg="${msg:-"$(lc 'Please answer the following questions.')"}"
+
+  if "ui#supportsTX"; then 
+    local ui__formStrategy=TX
+    local -ga __FORM_ARGS
+    local -ga __FORM_DATA
+    local -ga __CONFIRM_PARAMETERS
+    local -gA __VERIFIERS
+    exec 3</dev/null
+  else
+    local ui__formStrategy=SEQ
+    exec 3</dev/tty
+  fi
+
+  local -a __varNames=()
+  local -a __formCommands=()
+  while read -r; do
+    local _varname=${REPLY%%=*}
+    local _cmd=${REPLY#*=}
+    [ -n "$REPLY" ] || continue
+
+    __varNames+=("$_varname")
+    __formCommands+=("use_var=${_varname} $_cmd")
+  done
+
+  # declare all form variables as locals and then run the commands of the input given on stdin (`varname=ui command`),
+  # but prefixed with `use_var=varName` accordingly, so that validators and results are set up correctly.
+  # The actual effect and behaviour of this block differs depending on `ui__formStrategy`
+  # - In TX mode: The actions are expected to recognize being run in TX mode and only provide configuration
+  #   arguments through `__FORM_ARGS`, `__FORM_DATA`, `__VERIFIERS` and `__CONFIRM_PARAMETERS`
+  # - In SEQ mode: This will basically yield validated results directly, as all action types should be
+  #   coded in a self-sufficient way, repeatedly asking and validating input if required.
+  # shellcheck disable=1090
+  source <(
+    printf 'local %s=""\n' "${__varNames[@]}"
+    printf '%s\n' "${__formCommands[@]}" 
+  ) <&3
+
+  if "ui#isTX"; then
+    local -A __form_result
+    "ui#runFormImpl" "$msg" || return "$?"
+
+    # map raw values to their final results
+    for n in "${__varNames[@]}"; do
+      unset "$n"
+      local "$n=${__form_result[$n]}"
+    done
+  fi
+
+  # handling result
+  if ! [ -v use_var ]; then
+    # The printf itself should not expand, it generates code to be sourced.
+    # Reason: What is needed here is not the expansion of the array of var names, 
+    # but **sourceable** output printing assignment statements for the referenced vars.
+    # shellcheck disable=1090,2016
+    source <( printf 'echo ${%s[@]@A}\n' "${__varNames[@]}" )
+  else
+    local -n target="$use_var"
+    for _varname in "${__varNames[@]}"; do
+      target["$_varname"]="${!_varname}"
+    done 
+  fi
 }
 
 # @endsection

--- a/test/shell/opt/batocera-emulationstation/lib/ui/gui.shl.test.js
+++ b/test/shell/opt/batocera-emulationstation/lib/ui/gui.shl.test.js
@@ -17,7 +17,20 @@ class UiInteractionTest extends ShellTestRunner {
     this.testFile(FILE_UNDER_TEST);
     this.verifyFunction('tty', { code: 1 });
     this.environment({ HOME: process.env.ES_HOME, DISPLAY: ":0" });
+    this.postActions(`source "$SH_LIB_DIR"/generic-utils.shl`);
   }
+
+  static formApiImplemented = parameterized([
+    'ui:requestConfirmation', 'ui:ask', 'ui:askChoice', 'ui:askDirectory', 'ui:askFile'
+  ], function(uiFunction) {
+    this.verifyFunction('ui#isTX', { code: 0 })
+    this.postActions(
+      this.functionVerifiers['ui#isTX'],
+      'function ui#baseDialog { _printException "Should not be called in TX mode!" >&2; exit 1; }',
+      `use_var=ABC ${uiFunction} 'Answer?'`
+    );
+    this.execute();
+  })
 
   verifyBackendStyle() {
     this.verifyVariable('ui__interfaceBackend', 'GUI');


### PR DESCRIPTION
This PR finalizes a first version of generic form/questionaire support.

Questions can be used in TTY and GUI, but only GUI supports an all-in-one dialog for now.
There is no concept yet how to do something similar for TTY (with a similar level of comfort and verification) without asking (and repeating) one-by-one.

closes #144 