### PR TITLE
Feature: ui message channel

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -3,5 +3,8 @@ source-path=SCRIPTDIR
 source-path=sources/fs-root
 source-path=sources/fs-root/opt/batocera-emulationstation/lib
 external-sources=true
-disable=2329
-disable=2155
+
+disable=1090 # none-constant input to source
+disable=2155 # split declare and assign to prevent masking exit codes
+disable=2207 # prefer mapfile or read -a
+disable=2329 # never invoked: shellcheck can't properly handle functions with '#' in their names

--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/backend-api.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/backend-api.shl
@@ -91,6 +91,17 @@ function ui#requestInputImpl
 { echo "NOT SUPPORTED" >&2 && exit 1; }
 
 # @description
+# While running a script or installation, there might be multiple lines of simple information to share with the user.
+# These do not always require a feedback but only provide progress reports.  
+# It is up to the backend implementation to set up an **updateable** representation of messages.  
+# Do not open a new dialog/window/whatever in the backend implementation for each call to this function
+# as that is an absolute usability nightmare.
+#
+# @arg $1 full message string to show
+function ui#sendMessage
+{ echo "NOT SUPPORTED" >&2 && exit 1; }
+
+# @description
 # Ask the user for a group of several input values, presented at once (something like a form or dialog).    
 # The fields and values are expected to be supplied by [ui#formAddField](#uiformaddfield) 
 # and the series of `ui#ask*` functions.  

--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
@@ -66,10 +66,17 @@ function ui#requestChoiceImpl
 # @see [ui#requestConfirmationImpl](./backend-api.shl.md#uirequestConfirmationImpl)
 function ui#requestConfirmationImpl
 {
+  local buttons=()
+  if [ "$1" = "--labels" ]; then
+    shift
+    buttons+=("$2\!gtk-cancel:1" "$1\!gtk-ok:0")
+  else
+    buttons+=('yad-no:1' 'yad-yes:0')
+  fi
   "ui#baseDialog" \
     --title="$(lc 'Please confirm')" \
     --question "--text=${1}" \
-    --button='yad-no:1' --button='yad-yes:0' > /dev/null
+    "${buttons[@]/*/--button=\'&\'}" > /dev/null
 }
 
 # @description GUI-style implementation of asking for a directory.
@@ -328,7 +335,7 @@ function ui#verifyFormVars
 # Implementation of a verifier for choice-questions in forms.
 # @arg $1 name of array containing original choice keys (provided by ui:askChoice)
 # @arg $2 (changed) value of the current loop iteration/retry
-function ui#verifyChoice 
+function ui#verifyChoice
 {
   local -n arr="$1"
   local -n localizedValues="$1_iniData"

--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/gui.shl
@@ -119,6 +119,29 @@ function ui#requestInputImpl
   'ui#baseDialog' --entry --text="$1" --entry-text="$2"
 }
 
+# @description GUI-style implementation for sending a simple info message.  
+# This function is a lot more complicated than its TTY counterpart because there is no permanent 'text viewer'
+# in this backend. Processes launched with GUI style only show dialogues where requested and they are not launched
+# by typing a command in a terminal (normally).  
+#
+# Therefore, this backend must do more than just printing a message:
+# 1. First it provide a 'viewer' after checking if it exists (to prevent duplicates)
+# 2. The 'viewer' must be initialised and connected to the process via IPC or stdin/stdout
+# 3. It must auto-close with the process itself. The UI backend can be called from any kind of script.  
+#    Using exit traps is not an option as some other scripts already install custom exit hooks.
+#
+# This implementation uses bash coprocessing in combination with `yad --text-info --tail` 
+# to spawn a parallel log window.
+# 
+# @see [ui#sendMessage](./backend-api.shl.md#uisendMessage)
+function ui#sendMessage
+{
+  if [ -z "${gui__logBox[1]}" ]; then
+    "ui#spawnLogbox"
+  fi
+  # TODO: color support by pango-markup transformation of shell color hints?
+  printf '%s\n' "$1" >&"${gui__logBox[1]}"
+}
 # @endsection
 
 # -----------
@@ -352,6 +375,36 @@ function ui#verifyChoice
 function ui#verifyPassActual
 {
   printf '%s' "$1"
+}
+
+# @description
+# This function initialises the message viewer window. It forks one process named `gui__logBox` with `coproc`.  
+# That subprocess contains the following steps:
+# 1. Fork a yad dialog which tails `stdin`
+# 2. capture its PID to install an exit trap
+# 3. `tail` the PID to keep the subprocess alive
+#
+# Coproc is used because it is a convenient way to avoid named pipes, sockets and temporary files.  
+# The trap is required because yad does not close by itself when stdin closes.
+#
+# What actually happens here:
+# 1. yad runs forked, updating itself when input is sent to `${gui__logBox[1]}`.  
+#    This is required to get its PID with `$!`.
+# 2. The trap triggers when when the parent shell dies, dragging the subprocess down with it.
+# 3. This kills yad
+# 4. The subprocess kept alive by tail dies.
+# 5. The `tail`` is required to prevent the trap from triggering too early.  
+#    Without it, the subprocess would complete after installing the trap, it would lose sight of the forked yad  
+#    and leave it alone to reparent itself (which is NOT desired).
+function ui#spawnLogbox
+{
+  local title=$(lc "Messages for '%%1%%'", "$(basename "$0")")
+  coproc gui__logBox {
+    "ui#baseDialog" --title="$title" --text-info --tail --no-buttons &
+    ID="$!"
+    trap "kill -s SIGUSR1 ${ID}" EXIT
+    tail -f --pid="$ID" </dev/null
+  }
 }
 
 # @endsection

--- a/sources/fs-root/opt/batocera-emulationstation/lib/ui/tty.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/ui/tty.shl
@@ -104,6 +104,15 @@ function ui#requestInputImpl
   [ -n "$REPLY" ] || return 1
 }
 
+# @description TTY-style implementation for sending a simple info message. Just prints to tty/stdout.
+# @see [ui#sendMessage](./backend-api.shl.md#uisendMessage)
+function ui#sendMessage
+{
+  # `_outOnly` uses `lc` internally as well, to translate and replace parameters
+  # but `ui:message` did that already - so skip it this time around
+  NO_LC=1 _outOnly "$1"
+}
+
 # @endsection
 
 # -----------

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
@@ -29,12 +29,17 @@
 # - `stderr` should not be swallowed or redirected by the caller as some UI styles use it for messages to the user.
 
 # @section Public API
+# @description
+# This section desribes the API available to callers (developers).
+# The implementations here delegate some of the backend-specific work to a common internal API.
+# Any backend implementation to be used/supported by `user-interface.shl` must provide matching implementations.
+#
+# @see [Backend API](./ui/backend-api.shl.md) for details and contracts of the backend-specific API
 
 # @description
-# This is a proxy for other API functions contained in this library. Basically only invokes `ui:$1 "${@:2}"`.  
+# This is a proxy for other API functions contained in this library. It basically only invokes `ui:$1 "${@:2}"`.  
 # For regular shell coding alone this is not required. However, all ui functions which produce messages
-# do internally use [lc](./generic-utils.shl.md#lc) 
-# with their arguments to generate localized messages.  
+# use [lc](./generic-utils.shl.md#lc) internally with their arguments to generate localized messages.  
 # `xgettext` which is used to collect message ids can't handle keywords containing ':'. 
 # Thus, the code either would have to
 # 1. manually call `lc` everywhere instead of encapsulating it, then pass to the ui methods
@@ -52,12 +57,14 @@ function ui {
   fi
 }
 
-# @description Ask a single yes/no question.  
-# Form implementations will use a boolean input like a checkbox or switch
+# @description A simple yes/no question. The default prompt when nothing is given is 'Are you sure?'.  
+# The form implementations will use a boolean input like a checkbox or switch
 #
 # @arg $1 string prompt string
-# @arg $2 - $n arguments for `ui#runLc` until the first appearance of a long option (--, or one of the options defined)
-# @options --default for forms. Initial state of the widget.
+# @arg $2 - $n arguments for `ui#runLc` until the first appearance of any long option or `--`
+# @option --default **Forms only**: Initial state of the widget.
+# @option --labels **Regular question only**: The next 2 arguments specify the texts/words used for 'confirm' and 'deny'.  
+#         Localization must be done by the caller. Not all backends might support label customization (--labels will be ignored).
 function ui:requestConfirmation {
   ${ "ui#runLc" "$@"; } || __userMessage=$(lc 'Are you sure?')
 
@@ -67,11 +74,11 @@ function ui:requestConfirmation {
       initialValue=true
     fi
 
-    "ui#formAddField" CHK "${use_var:?need var name for form}" "$__userMessage" "${initialValue}"
+    "ui#formAddField" CHK "${use_var:?need var name for form}" "${__userMessage}" "${initialValue}"
     return 0
   fi
 
-  if "ui#requestConfirmationImpl" "$__userMessage"; then 
+  if "ui#requestConfirmationImpl" "${__userMessage}" "$@"; then 
     "ui#resultOut" "true" && return 0
   else
     "ui#resultOut" "false" && return 1
@@ -119,10 +126,10 @@ function ui:ask {
 # @stdin lines in the form "simple string" or "some_key::simple string". Only read when not a terminal, up to 25 lines.
 # @stdout choice_id of user's selection (defaults to choice_text)
 # @arg $1 string prompt string
-# @arg $2 - $n arguments for `ui#runLc` until the first appearance of a long option (--, or one of the options defined)
-# @option --optional return an empty string instead of exiting when cancel is chosen.
+# @arg $2 - $n arguments for `ui#runLc` until the first appearance of any long option or `--`
+# @option --optional Return an empty string instead of exiting when cancel is chosen.
 # @option --default <key> of value to pre-select. Defaults to first entry if not given.
-# @option --choices All arguments following this will be interpreted as choices for the list. Most be given as last option/argument.
+# @option --choices All arguments following this will be interpreted as choices for the list. Must be given as last option/argument.
 function ui:askChoice {
   ${ "ui#runLc" "$@"; } || __userMessage=$(lc 'Please pick one of the choices')
   local __optional=""
@@ -201,7 +208,7 @@ EOF
 #
 # Backend providers must implement `iu#requestDirectoryImpl`.
 # @arg $1 string prompt string
-# @arg $2 - $n arguments for `ui#runLc` until the first appearance of a long option (--, or one of the options defined)
+# @arg $2 - $n arguments for `ui#runLc` until the first appearance of any long option or `--`
 # @option --default The question should fill this path as default / starting point.
 # @option --optional script will not exit on user cancel, but return an empty string instead
 function ui:askDirectory {
@@ -233,7 +240,7 @@ function ui:askDirectory {
 #
 # Backend providers must implement `ui#requestFileImpl`.
 # @arg $1 string prompt string
-# @arg $2 - $n arguments for `ui#runLc` until the first appearance of a long option (--, or one of the options defined)
+# @arg $2 - $n arguments for `ui#runLc` until the first appearance of any long option or `--`
 # @option --default The question should fill this path as default / starting point.
 # @option --types file endings (without leading dot)
 # @option --optional script will not exit on user cancel, but return an empty string instead
@@ -430,7 +437,7 @@ function ui:form {
 # @section Value verifier functions
 # @internal
 # @description
-# The functions defined in this section are intended to be used from inside any `ui:*` or `uu#*` function where required.  
+# The functions defined in this section are intended to be used from inside any `ui:*` or `ui#*` function where required.  
 # Their primary purpose is to verify user input.  
 #
 # All verifier functions follow the same basic behaviour:

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
@@ -275,6 +275,27 @@ function ui:askFile {
   "ui#resultOut" "$REPLY"
 }
 
+# @description
+# Send a short message/progress report to the user.  
+# To be used for information not needing confirmation, so that a user has a bit of a trace on what's happening.
+#
+# Contrary to most other public `ui` interaction functions, this one does not provide a default question/label
+# as that would be pointless. At the very least, `$1` must be provided or the function will consider it to be
+# a coding error and exit the process.
+#
+# Backends **MUST** implement and support this by providing `ui#sendMessage`, or provide a NOOP override for
+# the default `not supported` stub.
+#
+# @arg $1 string prompt string
+# @arg $2 - $n arguments for `ui#runLc` until the first appearance of any long option or `--` (optional)
+function ui:message {
+  ${ "ui#runLc" "$@"; } || {
+    _printException _logOnly "ui:message was called without a message to show"
+    return 0
+  }
+  "ui#sendMessage" "${__userMessage}"
+}
+
 # @description Log a message and send it to the user, then exit shell
 # @arg $1 string `lc` string
 # @arg $2 -$n replacement strings (optional)

--- a/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
+++ b/sources/fs-root/opt/batocera-emulationstation/lib/user-interface.shl
@@ -38,9 +38,10 @@
 
 # @description
 # This is a proxy for other API functions contained in this library. It basically only invokes `ui:$1 "${@:2}"`.  
-# For regular shell coding alone this is not required. However, all ui functions which produce messages
-# use [lc](./generic-utils.shl.md#lc) internally with their arguments to generate localized messages.  
-# `xgettext` which is used to collect message ids can't handle keywords containing ':'. 
+# The proxy was introduced to make working with `xgettext` easier because `xgettext` can't handle keywords containing `:`.  
+# Therefore it is not able collect translatable strings for `ui:...` functions by regular parameter definition. To work around this
+# limitation, `ui` is introduced as a standalone keyword.
+# 
 # Thus, the code either would have to
 # 1. manually call `lc` everywhere instead of encapsulating it, then pass to the ui methods
 # 2. manipulate the input to `xgettext` on the fly to change keywords


### PR DESCRIPTION
Add an API and backend implementations for simple feedback/progress report to the user.

`ui:message` is meant for info which doesn't need acknowlegments.
- in `TTY`, it will just print a new line to the console
- in `GUI` mode, first usage of the function forks a new dialog subprocess with a scrolling text box listening to stdin. All messages sent via `ui:message` will then be piped into this subprocess.

TODO: 
- message channel in `GUI` mode might need a switch to be 'silenced' - otherwise there is the danger that too many unimportant log lines might open the message box dialog, e.g. when only a game is expected to be launched.
- window size and position